### PR TITLE
Refactor runtime and artifact path handling

### DIFF
--- a/docs/ai/documentation-governance.md
+++ b/docs/ai/documentation-governance.md
@@ -110,6 +110,8 @@ la revisión documental deja de ser genérica y pasa a ser **dirigida**:
 
 Esta capa está pensada para las piezas donde la deriva documental es más peligrosa: arquitectura principal, contratos, operación y gobernanza.
 
+En la práctica, esto también aplica a refactors internos que no cambian la funcionalidad visible pero sí la forma en que el sistema resuelve entorno, rutas o artefactos operativos. Si un cambio mueve esa lógica a helpers compartidos como `pipeline_runtime.py` o `runtime_paths.py`, la revisión documental sigue siendo obligatoria porque cambia la superficie real que sostienen los playbooks, la arquitectura operativa y las reglas de trazabilidad.
+
 ## Tratamiento del material heredado
 
 - `GEMINI.md` se mantiene como adaptador operativo en transición.

--- a/docs/architecture/global-commercial-pipelines.md
+++ b/docs/architecture/global-commercial-pipelines.md
@@ -7,6 +7,7 @@ source_of_truth:
   - ../../src/assessment_engine/scripts/run_executive_refiner.py
   - ../../src/assessment_engine/scripts/run_commercial_pipeline.py
   - ../../src/assessment_engine/scripts/run_commercial_refiner.py
+  - ../../src/assessment_engine/scripts/lib/pipeline_runtime.py
   - ../../src/assessment_engine/schemas/global_report.py
   - ../../src/assessment_engine/schemas/commercial.py
 last_verified_against: 2026-04-30
@@ -65,6 +66,14 @@ Trabaja sobre:
 5. **Render Global DOCX**
    - script: `render_global_report_from_template`
    - salida final: `Informe_Ejecutivo_Consolidado_<client>.docx`
+
+### Nota operativa actual
+
+El orquestador global ya comparte con la capa comercial una base común de:
+
+- resolución de intérprete Python;
+- bootstrap de entorno;
+- propagación explícita del entorno validado a cada paso del pipeline.
 
 ## Cómo se construye el payload global
 
@@ -142,6 +151,8 @@ Y genera:
 
 2. **Render Account Action Plan**
    - script: `render_commercial_report`
+
+Igual que en la capa global, la ejecución actual reutiliza un runner común para evitar deriva entre preflight, variables de entorno y pasos hijos.
 
 ## Contexto híbrido comercial
 

--- a/docs/architecture/tower-pipeline.md
+++ b/docs/architecture/tower-pipeline.md
@@ -5,6 +5,7 @@ source_of_truth:
   - ../../src/assessment_engine/scripts/run_tower_pipeline.py
   - ../../src/assessment_engine/scripts/run_tower_blueprint_engine.py
   - ../../src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+  - ../../src/assessment_engine/scripts/lib/pipeline_runtime.py
   - ../../src/assessment_engine/schemas/blueprint.py
   - ../../src/assessment_engine/schemas/annex_synthesis.py
 last_verified_against: 2026-04-30
@@ -55,6 +56,12 @@ El orquestador fija variables de entorno como:
 - `ASSESSMENT_TOWER_ID`
 - `ASSESSMENT_CASE_DIR`
 - `PYTHONPATH`
+
+Además, la torre comparte ya con las capas global y comercial una base común de runtime para:
+
+- resolver el intérprete Python;
+- bootstrap de entorno;
+- defaults de ejecución.
 
 Además exige configuración de Vertex AI mediante:
 

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -212,6 +212,7 @@ entries:
       - src/assessment_engine/scripts/run_tower_pipeline.py
       - src/assessment_engine/scripts/run_tower_blueprint_engine.py
       - src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+      - src/assessment_engine/scripts/lib/pipeline_runtime.py
       - src/assessment_engine/schemas/blueprint.py
       - src/assessment_engine/schemas/annex_synthesis.py
     enforce_on_source_changes: true
@@ -240,6 +241,7 @@ entries:
       - src/assessment_engine/scripts/run_executive_refiner.py
       - src/assessment_engine/scripts/run_commercial_pipeline.py
       - src/assessment_engine/scripts/run_commercial_refiner.py
+      - src/assessment_engine/scripts/lib/pipeline_runtime.py
       - src/assessment_engine/schemas/global_report.py
       - src/assessment_engine/schemas/commercial.py
     enforce_on_source_changes: true
@@ -455,6 +457,7 @@ entries:
       - src/assessment_engine/scripts/run_commercial_pipeline.py
       - src/assessment_engine/scripts/run_intelligence_harvesting.py
       - src/assessment_engine/scripts/render_web_presentation.py
+      - src/assessment_engine/scripts/lib/pipeline_runtime.py
     enforce_on_source_changes: true
     review_paths_on_source_change:
       - docs/operations/pipeline-execution.md

--- a/docs/operations/pipeline-execution.md
+++ b/docs/operations/pipeline-execution.md
@@ -7,6 +7,7 @@ source_of_truth:
   - ../../src/assessment_engine/scripts/run_commercial_pipeline.py
   - ../../src/assessment_engine/scripts/run_intelligence_harvesting.py
   - ../../src/assessment_engine/scripts/render_web_presentation.py
+  - ../../src/assessment_engine/scripts/lib/pipeline_runtime.py
   - ../architecture/tower-pipeline.md
   - ../architecture/global-commercial-pipelines.md
 last_verified_against: 2026-04-30
@@ -56,6 +57,8 @@ Comando:
   --responses-file /ruta/a/respuestas.txt
 ```
 
+El entrypoint por torre comparte ya el mismo bootstrap base de runtime que usan los pipelines global y comercial.
+
 Reanudación opcional:
 
 ```bash
@@ -81,6 +84,8 @@ Comando:
 ```bash
 ./.venv/bin/python -m assessment_engine.scripts.run_global_pipeline <client_name>
 ```
+
+El entrypoint global ya comparte con el comercial el mismo bootstrap de entorno y de resolución del intérprete Python, para que el preflight y los pasos internos trabajen con el mismo contexto efectivo.
 
 ## 4. Pipeline comercial
 

--- a/docs/operations/smoke-regeneration.md
+++ b/docs/operations/smoke-regeneration.md
@@ -89,6 +89,8 @@ El repo incorpora el entrypoint:
 ./.venv/bin/python -m assessment_engine.scripts.tools.regenerate_smoke_artifacts
 ```
 
+El runner ya no resuelve de forma dispersa el bootstrap del runtime ni las rutas principales del caso smoke. La preparación del entorno compartido, la resolución de `working/`, `client_dir`, `case_dir` y varias rutas de artefactos/payloads viven ahora en helpers comunes (`pipeline_runtime.py` y `runtime_paths.py`), lo que reduce divergencias entre el flujo de torre, los pipelines global/commercial y el dashboard web.
+
 Por defecto trabaja sobre:
 
 - cliente: `smoke_ivirma`
@@ -151,6 +153,8 @@ El runner genera primero la parte local y después reanuda `run_tower_pipeline.p
 - `Engine: Tower Strategic Blueprint`
 
 Así evita repetir las fases deterministas y deja explícita la frontera entre preparación local y síntesis asistida por IA.
+
+Además, el smoke conserva compatibilidad con la resolución legacy de `working/` cuando algún consumidor aún arranca desde rutas antiguas, pero la ruta preferida y documentada pasa a ser la capa común de helpers de runtime/path.
 
 ### 4. Extender el smoke a outputs globales, comerciales y web
 

--- a/src/assessment_engine/scripts/build_case_input.py
+++ b/src/assessment_engine/scripts/build_case_input.py
@@ -5,15 +5,16 @@ Contiene la lógica y utilidades principales para el pipeline de Assessment Engi
 import argparse
 import json
 import re
-import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
-
-from assessment_engine.scripts.lib.text_utils import normalize_tower_name, slugify
 from zipfile import ZipFile
 
-from assessment_engine.scripts.lib.runtime_paths import ROOT
-
+from assessment_engine.scripts.lib.runtime_paths import (
+    ROOT,
+    resolve_case_dir,
+    resolve_client_intelligence_path,
+)
+from assessment_engine.scripts.lib.text_utils import normalize_tower_name, slugify
 
 RESPONSE_RE = re.compile(r"(T\d+\.P\d+\.K\d+\.PR\d+)\s*:\s*([1-5](?:[.,]\d+)?)")
 
@@ -138,7 +139,7 @@ def build_case_input(args: argparse.Namespace) -> dict:
         source_documents.insert(2, matrix_file_name)
 
     client_slug = slugify(args.client)
-    intel_path = ROOT / "working" / client_slug / "client_intelligence.json"
+    intel_path = resolve_client_intelligence_path(client_slug)
     target_maturity = 4.0
     if intel_path.exists():
         try:
@@ -200,7 +201,7 @@ def main() -> None:
     args = parser.parse_args()
 
     client_slug = slugify(args.client)
-    case_dir = ROOT / "working" / client_slug / args.tower
+    case_dir = resolve_case_dir(client_slug, args.tower)
     case_dir.mkdir(parents=True, exist_ok=True)
 
     case_input = build_case_input(args)

--- a/src/assessment_engine/scripts/lib/pipeline_runtime.py
+++ b/src/assessment_engine/scripts/lib/pipeline_runtime.py
@@ -1,0 +1,74 @@
+"""
+Helpers comunes para entrypoints de pipeline basados en módulos Python.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from assessment_engine.scripts.lib.runtime_env import ensure_google_cloud_env_defaults
+from assessment_engine.scripts.lib.runtime_paths import ROOT
+
+
+def resolve_python_bin() -> str:
+    venv_python = ROOT / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def build_runtime_env(
+    base_env: dict[str, str] | None = None,
+    *,
+    include_pythonpath: bool = True,
+) -> dict[str, str]:
+    env = os.environ.copy() if base_env is None else dict(base_env)
+    ensure_google_cloud_env_defaults(env)
+    if include_pythonpath:
+        env["PYTHONPATH"] = str(ROOT / "src")
+    return env
+
+
+def run_module_step(cmd_args: list[str], step_name: str, env: dict[str, str]) -> None:
+    print(f"\n=== {step_name} ===")
+
+    if len(cmd_args) < 3 or cmd_args[1] != "-m":
+        raise ValueError(f"Comando no soportado por run_module_step: {cmd_args}")
+
+    module_name = cmd_args[2]
+    script_args = cmd_args[3:]
+    process_env = build_runtime_env(env)
+    original_env = os.environ.copy()
+    mock_argv = [module_name] + script_args
+
+    try:
+        os.environ.clear()
+        os.environ.update(process_env)
+        with patch.object(sys, "argv", mock_argv):
+            mod = importlib.import_module(module_name)
+            importlib.reload(mod)
+            if not hasattr(mod, "main"):
+                raise RuntimeError(f"El módulo {module_name} no tiene función main()")
+
+            result = mod.main()
+            if asyncio.iscoroutine(result):
+                asyncio.run(result)
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            raise RuntimeError(
+                f"Fallo nativo (SystemExit) en {step_name} con código: {exc.code}"
+            ) from exc
+        print(f"[{step_name}] Finalizado con exit(0)")
+    except Exception as exc:
+        import traceback
+
+        traceback.print_exc()
+        raise RuntimeError(f"Fallo nativo en {step_name} con error: {exc}") from exc
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)

--- a/src/assessment_engine/scripts/lib/pipeline_runtime.py
+++ b/src/assessment_engine/scripts/lib/pipeline_runtime.py
@@ -2,8 +2,6 @@
 Helpers comunes para entrypoints de pipeline basados en módulos Python.
 """
 
-from __future__ import annotations
-
 import asyncio
 import importlib
 import os
@@ -12,7 +10,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 from assessment_engine.scripts.lib.runtime_env import ensure_google_cloud_env_defaults
-from assessment_engine.scripts.lib.runtime_paths import ROOT
+from assessment_engine.scripts.lib.runtime_paths import ROOT, resolve_client_dir
+
+AI_STEP_TIMEOUT_ENV = "ASSESSMENT_AI_STEP_TIMEOUT_SECONDS"
 
 
 def resolve_python_bin() -> str:
@@ -32,6 +32,54 @@ def build_runtime_env(
     if include_pythonpath:
         env["PYTHONPATH"] = str(ROOT / "src")
     return env
+
+
+def prepare_case_runtime(
+    env: dict[str, str],
+    *,
+    client_id: str,
+    tower_id: str,
+) -> Path:
+    case_dir = resolve_client_dir(client_id) / tower_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+    env["ASSESSMENT_CLIENT_ID"] = client_id
+    env["ASSESSMENT_TOWER_ID"] = tower_id
+    env["ASSESSMENT_CASE_DIR"] = str(case_dir)
+    return case_dir
+
+
+def validate_runtime_environment(env: dict[str, str]) -> None:
+    missing_vars = [
+        name
+        for name in ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
+        if not env.get(name, "").strip()
+    ]
+    if missing_vars:
+        raise RuntimeError("Falta configuración de entorno para Vertex AI.")
+
+
+def resolve_ai_step_timeout_seconds(
+    env: dict[str, str],
+    step_name: str,
+) -> float | None:
+    if "Engine:" not in step_name and "Refinement" not in step_name:
+        return None
+
+    raw_value = str(env.get(AI_STEP_TIMEOUT_ENV, "")).strip()
+    if not raw_value:
+        return None
+
+    try:
+        timeout_seconds = float(raw_value)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{AI_STEP_TIMEOUT_ENV} debe ser un número positivo."
+        ) from exc
+
+    if timeout_seconds <= 0:
+        raise RuntimeError(f"{AI_STEP_TIMEOUT_ENV} debe ser mayor que 0.")
+
+    return timeout_seconds
 
 
 def run_module_step(cmd_args: list[str], step_name: str, env: dict[str, str]) -> None:

--- a/src/assessment_engine/scripts/lib/runtime_paths.py
+++ b/src/assessment_engine/scripts/lib/runtime_paths.py
@@ -5,8 +5,11 @@ Contiene la lógica y utilidades principales para el pipeline de Assessment Engi
 import os
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[4]
+
+
+def resolve_working_dir() -> Path:
+    return ROOT / "working"
 
 
 def resolve_tower_id(default: str = "T5") -> str:
@@ -17,11 +20,15 @@ def resolve_client_id(default: str = "generic_client") -> str:
     return os.environ.get("ASSESSMENT_CLIENT_ID", default).strip() or default
 
 
+def resolve_client_dir(default_client: str = "generic_client") -> Path:
+    return resolve_working_dir() / resolve_client_id(default_client)
+
+
 def resolve_case_dir(default_client: str = "generic_client", default_tower: str = "T1") -> Path:
     override = os.environ.get("ASSESSMENT_CASE_DIR", "").strip()
     if override:
         return Path(override).resolve()
-    return ROOT / "working" / resolve_client_id(default_client) / resolve_tower_id(default_tower)
+    return resolve_client_dir(default_client) / resolve_tower_id(default_tower)
 
 
 def resolve_tower_definition_file(default_tower: str = "T5") -> Path:

--- a/src/assessment_engine/scripts/lib/runtime_paths.py
+++ b/src/assessment_engine/scripts/lib/runtime_paths.py
@@ -6,6 +6,9 @@ import os
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
+GLOBAL_REPORT_TEMPLATE_NAME = "11. Template Documento General Alpha v.05.docx"
+TOWER_ANNEX_TEMPLATE_NAME = "Template_Documento_Anexos_Alpha_v06_Tower_Annex_v2_6.docx"
+WEB_DASHBOARD_TEMPLATE_NAME = "web_dashboard.html"
 
 
 def resolve_working_dir() -> Path:
@@ -21,7 +24,12 @@ def resolve_client_id(default: str = "generic_client") -> str:
 
 
 def resolve_client_dir(default_client: str = "generic_client") -> Path:
-    return resolve_working_dir() / resolve_client_id(default_client)
+    client_id = resolve_client_id(default_client)
+    primary = resolve_working_dir() / client_id
+    legacy = ROOT / "src" / "assessment_engine" / "working" / client_id
+    if primary.exists() or not legacy.exists():
+        return primary
+    return legacy
 
 
 def resolve_case_dir(default_client: str = "generic_client", default_tower: str = "T1") -> Path:
@@ -31,6 +39,78 @@ def resolve_case_dir(default_client: str = "generic_client", default_tower: str 
     return resolve_client_dir(default_client) / resolve_tower_id(default_tower)
 
 
+def resolve_case_input_path(
+    default_client: str = "generic_client",
+    default_tower: str = "T1",
+) -> Path:
+    return resolve_case_dir(default_client, default_tower) / "case_input.json"
+
+
+def resolve_client_intelligence_path(default_client: str = "generic_client") -> Path:
+    return resolve_client_dir(default_client) / "client_intelligence.json"
+
+
+def resolve_global_report_payload_path(default_client: str = "generic_client") -> Path:
+    return resolve_client_dir(default_client) / "global_report_payload.json"
+
+
+def resolve_commercial_report_payload_path(default_client: str = "generic_client") -> Path:
+    return resolve_client_dir(default_client) / "commercial_report_payload.json"
+
+
+def resolve_blueprint_payload_filename(tower_id: str) -> str:
+    return f"blueprint_{tower_id.lower()}_payload.json"
+
+
+def resolve_blueprint_payload_path(
+    default_client: str = "generic_client",
+    default_tower: str = "T5",
+) -> Path:
+    tower_id = resolve_tower_id(default_tower)
+    return resolve_case_dir(default_client, tower_id) / resolve_blueprint_payload_filename(
+        tower_id
+    )
+
+
+def resolve_blueprint_payload_candidates(
+    default_client: str = "generic_client",
+    default_tower: str = "T5",
+) -> tuple[Path, ...]:
+    tower_id = resolve_tower_id(default_tower)
+    case_dir = resolve_case_dir(default_client, tower_id)
+    return (
+        case_dir / resolve_blueprint_payload_filename(tower_id),
+        case_dir / f"blueprint_{tower_id.upper()}_payload.json",
+    )
+
+
+def resolve_annex_template_payload_filename(tower_id: str) -> str:
+    return f"approved_annex_{tower_id.lower()}.template_payload.json"
+
+
+def resolve_annex_template_payload_path(
+    default_client: str = "generic_client",
+    default_tower: str = "T5",
+) -> Path:
+    tower_id = resolve_tower_id(default_tower)
+    return resolve_case_dir(
+        default_client,
+        tower_id,
+    ) / resolve_annex_template_payload_filename(tower_id)
+
+
 def resolve_tower_definition_file(default_tower: str = "T5") -> Path:
     tower_id = resolve_tower_id(default_tower)
     return ROOT / "engine_config" / "towers" / tower_id / f"tower_definition_{tower_id}.json"
+
+
+def resolve_global_report_template_path() -> Path:
+    return ROOT / "source_docs" / "templates" / GLOBAL_REPORT_TEMPLATE_NAME
+
+
+def resolve_tower_annex_template_path() -> Path:
+    return ROOT / "templates" / TOWER_ANNEX_TEMPLATE_NAME
+
+
+def resolve_web_dashboard_template_path() -> Path:
+    return ROOT / "src" / "assessment_engine" / "templates" / WEB_DASHBOARD_TEMPLATE_NAME

--- a/src/assessment_engine/scripts/render_tower_blueprint.py
+++ b/src/assessment_engine/scripts/render_tower_blueprint.py
@@ -22,13 +22,16 @@ from assessment_engine.scripts.lib.docx_render_utils import (
     set_cell_text,
     shade_cell,
 )
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_annex_template_payload_path,
+    resolve_client_intelligence_path,
+    resolve_tower_annex_template_path,
+)
 from assessment_engine.scripts.lib.text_utils import clean_text_for_word
 
 BASE_TEXT_COLOR = RGBColor(46, 64, 77)
 ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_TEMPLATE_PATH = (
-    ROOT / "templates" / "Template_Documento_Anexos_Alpha_v06_Tower_Annex_v2_6.docx"
-)
+DEFAULT_TEMPLATE_PATH = resolve_tower_annex_template_path()
 
 
 def load_json(path: Path) -> dict:
@@ -155,15 +158,14 @@ def resolve_client_dir(payload_path: Path, payload_data: dict) -> Path:
 
 
 def load_client_intelligence(client_dir: Path) -> dict:
-    path = client_dir / "client_intelligence.json"
+    path = resolve_client_intelligence_path(client_dir.name)
     if path.exists():
         return load_json(path)
     return {}
 
 
 def load_annex_data(client_dir: Path, tower_code: str) -> dict:
-    tower_dir = client_dir / tower_code.upper()
-    path = tower_dir / f"approved_annex_{tower_code.lower()}.template_payload.json"
+    path = resolve_annex_template_payload_path(client_dir.name, tower_code.upper())
     if path.exists():
         return load_json(path)
     return {}

--- a/src/assessment_engine/scripts/render_tower_blueprint.py
+++ b/src/assessment_engine/scripts/render_tower_blueprint.py
@@ -15,6 +15,8 @@ from docx.shared import Inches, Pt, RGBColor
 from assessment_engine.schemas.blueprint import BlueprintPayload, PillarBlueprintDraft
 from assessment_engine.scripts.lib.docx_render_utils import (
     add_body_paragraph as _orig_add_body_paragraph,
+)
+from assessment_engine.scripts.lib.docx_render_utils import (
     add_heading_paragraph,
     autofit_table_to_contents,
     clear_paragraph,
@@ -23,8 +25,6 @@ from assessment_engine.scripts.lib.docx_render_utils import (
     shade_cell,
 )
 from assessment_engine.scripts.lib.runtime_paths import (
-    resolve_annex_template_payload_path,
-    resolve_client_intelligence_path,
     resolve_tower_annex_template_path,
 )
 from assessment_engine.scripts.lib.text_utils import clean_text_for_word
@@ -158,14 +158,15 @@ def resolve_client_dir(payload_path: Path, payload_data: dict) -> Path:
 
 
 def load_client_intelligence(client_dir: Path) -> dict:
-    path = resolve_client_intelligence_path(client_dir.name)
+    path = client_dir / "client_intelligence.json"
     if path.exists():
         return load_json(path)
     return {}
 
 
 def load_annex_data(client_dir: Path, tower_code: str) -> dict:
-    path = resolve_annex_template_payload_path(client_dir.name, tower_code.upper())
+    tower_dir = client_dir / tower_code.upper()
+    path = tower_dir / f"approved_annex_{tower_code.lower()}.template_payload.json"
     if path.exists():
         return load_json(path)
     return {}

--- a/src/assessment_engine/scripts/render_web_presentation.py
+++ b/src/assessment_engine/scripts/render_web_presentation.py
@@ -7,16 +7,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from assessment_engine.scripts.lib.runtime_paths import ROOT
-
-
-TEMPLATE_PATH = (
-    Path(__file__).resolve().parents[1] / "templates" / "web_dashboard.html"
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_blueprint_payload_candidates,
+    resolve_client_dir,
+    resolve_global_report_payload_path,
+    resolve_web_dashboard_template_path,
 )
-BLUEPRINT_NAME_CANDIDATES = (
-    "blueprint_{tower_lower}_payload.json",
-    "blueprint_{tower_upper}_payload.json",
-)
+
+TEMPLATE_PATH = resolve_web_dashboard_template_path()
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -24,23 +22,8 @@ def _load_json(path: Path) -> dict[str, Any]:
         return json.load(handle)
 
 
-def _resolve_client_dir(client_id: str) -> Path:
-    candidates = (
-        ROOT / "working" / client_id,
-        ROOT / "src" / "assessment_engine" / "working" / client_id,
-    )
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    return candidates[0]
-
-
 def _find_blueprint_payload(tower_dir: Path, tower_id: str) -> Path | None:
-    for pattern in BLUEPRINT_NAME_CANDIDATES:
-        candidate = tower_dir / pattern.format(
-            tower_lower=tower_id.lower(),
-            tower_upper=tower_id.upper(),
-        )
+    for candidate in resolve_blueprint_payload_candidates(tower_dir.parent.name, tower_id):
         if candidate.exists():
             return candidate
     return None
@@ -306,8 +289,8 @@ def _build_tower_nexus(
 
 
 def _build_nexus_data(client_id: str) -> tuple[dict[str, Any], Path]:
-    client_dir = _resolve_client_dir(client_id)
-    global_payload_path = client_dir / "global_report_payload.json"
+    client_dir = resolve_client_dir(client_id)
+    global_payload_path = resolve_global_report_payload_path(client_id)
     if not global_payload_path.exists():
         raise FileNotFoundError(
             f"No se encuentra el payload global: {global_payload_path}"

--- a/src/assessment_engine/scripts/run_commercial_pipeline.py
+++ b/src/assessment_engine/scripts/run_commercial_pipeline.py
@@ -10,7 +10,12 @@ from assessment_engine.scripts.lib.pipeline_runtime import (
     run_module_step,
 )
 from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
-from assessment_engine.scripts.lib.runtime_paths import ROOT, resolve_client_dir
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_client_dir,
+    resolve_commercial_report_payload_path,
+    resolve_global_report_payload_path,
+    resolve_global_report_template_path,
+)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -28,14 +33,9 @@ def main(argv: list[str] | None = None) -> None:
             f"(project={preflight['project']}, location={preflight['location']}, model={preflight['model']})"
         )
 
-    global_payload_path = client_dir / "global_report_payload.json"
-    commercial_payload_path = client_dir / "commercial_report_payload.json"
-    template_path = (
-        ROOT
-        / "source_docs"
-        / "templates"
-        / "11. Template Documento General Alpha v.05.docx"
-    )
+    global_payload_path = resolve_global_report_payload_path(client_name)
+    commercial_payload_path = resolve_commercial_report_payload_path(client_name)
+    template_path = resolve_global_report_template_path()
     output_path = client_dir / f"Account_Action_Plan_{client_name}.docx"
 
     python_bin = resolve_python_bin()

--- a/src/assessment_engine/scripts/run_commercial_pipeline.py
+++ b/src/assessment_engine/scripts/run_commercial_pipeline.py
@@ -2,55 +2,15 @@
 Módulo run_commercial_pipeline.py.
 Contiene la lógica y utilidades principales para el pipeline de Assessment Engine.
 """
-import os
 import sys
-import importlib
-import asyncio
-from unittest.mock import patch
-from pathlib import Path
-from assessment_engine.scripts.lib.runtime_env import (
-    ensure_google_cloud_env_defaults,
-    run_vertex_ai_preflight,
+
+from assessment_engine.scripts.lib.pipeline_runtime import (
+    build_runtime_env,
+    resolve_python_bin,
+    run_module_step,
 )
-
-ROOT = Path(__file__).resolve().parents[3]
-
-
-def run_step(cmd_args: list[str], step_name: str, env: dict[str, str]) -> None:
-    print(f"\n=== {step_name} ===")
-
-    process_env = os.environ.copy()
-    process_env.update(env)
-    process_env["PYTHONPATH"] = str(ROOT / "src")
-    for k, v in process_env.items():
-        os.environ[k] = v
-
-    if len(cmd_args) >= 3 and cmd_args[1] == "-m":
-        module_name = cmd_args[2]
-        script_args = cmd_args[3:]
-    else:
-        raise ValueError(f"Comando no soportado por run_native_step: {cmd_args}")
-
-    mock_argv = [module_name] + script_args
-    try:
-        with patch.object(sys, 'argv', mock_argv):
-            mod = importlib.import_module(module_name)
-            importlib.reload(mod)
-            if hasattr(mod, 'main'):
-                result = mod.main()
-                if asyncio.iscoroutine(result):
-                    asyncio.run(result)
-            else:
-                raise RuntimeError(f"El módulo {module_name} no tiene función main()")
-    except SystemExit as e:
-        if e.code != 0 and e.code is not None:
-            raise RuntimeError(f"Fallo nativo (SystemExit) en {step_name} con código: {e.code}")
-        else:
-            print(f"[{step_name}] Finalizado con exit(0)")
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        raise RuntimeError(f"Fallo nativo en {step_name} con error: {e}")
+from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
+from assessment_engine.scripts.lib.runtime_paths import ROOT
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -60,9 +20,7 @@ def main(argv: list[str] | None = None) -> None:
 
     client_name = (argv if argv is not None else sys.argv)[1]
     client_dir = ROOT / "working" / client_name
-    env = os.environ.copy()
-    ensure_google_cloud_env_defaults(env)
-    env["PYTHONPATH"] = str(ROOT / "src")
+    env = build_runtime_env()
     if env.get("ASSESSMENT_SKIP_VERTEX_PREFLIGHT", "").strip() != "1":
         preflight = run_vertex_ai_preflight(env=env)
         print(
@@ -80,12 +38,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     output_path = client_dir / f"Account_Action_Plan_{client_name}.docx"
 
-    python_bin = str(ROOT / ".venv" / "bin" / "python")
-    if not Path(python_bin).exists():
-        python_bin = sys.executable
+    python_bin = resolve_python_bin()
 
     # 1. Ejecutar Refinador Comercial Multi-Agente
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.run_commercial_refiner",
@@ -96,7 +52,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # 2. Renderizar Documento Word Confidencial
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.render_commercial_report",

--- a/src/assessment_engine/scripts/run_commercial_pipeline.py
+++ b/src/assessment_engine/scripts/run_commercial_pipeline.py
@@ -10,7 +10,7 @@ from assessment_engine.scripts.lib.pipeline_runtime import (
     run_module_step,
 )
 from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
-from assessment_engine.scripts.lib.runtime_paths import ROOT
+from assessment_engine.scripts.lib.runtime_paths import ROOT, resolve_client_dir
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -19,7 +19,7 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
 
     client_name = (argv if argv is not None else sys.argv)[1]
-    client_dir = ROOT / "working" / client_name
+    client_dir = resolve_client_dir(client_name)
     env = build_runtime_env()
     if env.get("ASSESSMENT_SKIP_VERTEX_PREFLIGHT", "").strip() != "1":
         preflight = run_vertex_ai_preflight(env=env)

--- a/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+++ b/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
@@ -22,6 +22,7 @@ from assessment_engine.schemas.annex_synthesis import (
 )
 from assessment_engine.schemas.common import VersionMetadata
 from assessment_engine.scripts.lib.contract_utils import robust_load_payload
+from assessment_engine.scripts.lib.runtime_paths import resolve_client_dir
 from vertexai.agent_engines import AdkApp
 from google.adk.agents import Agent
 
@@ -495,7 +496,7 @@ async def synthesize_annex(client_name: str, tower_id: str):
     run_id = f"run_{uuid.uuid4()}"
     print(f"🧠 [Top-Down] Sintetizando Anexo Ejecutivo para {tower_id} (Run ID: {run_id})...")
     
-    client_dir = ROOT / "working" / client_name
+    client_dir = resolve_client_dir(client_name)
     tower_dir = client_dir / tower_id
     blueprint_path = tower_dir / f"blueprint_{tower_id.lower()}_payload.json"
     output_path = tower_dir / f"approved_annex_{tower_id.lower()}.template_payload.json"

--- a/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+++ b/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
@@ -22,7 +22,13 @@ from assessment_engine.schemas.annex_synthesis import (
 )
 from assessment_engine.schemas.common import VersionMetadata
 from assessment_engine.scripts.lib.contract_utils import robust_load_payload
-from assessment_engine.scripts.lib.runtime_paths import resolve_client_dir
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_annex_template_payload_path,
+    resolve_blueprint_payload_path,
+    resolve_case_input_path,
+    resolve_client_dir,
+    resolve_client_intelligence_path,
+)
 from vertexai.agent_engines import AdkApp
 from google.adk.agents import Agent
 
@@ -498,10 +504,10 @@ async def synthesize_annex(client_name: str, tower_id: str):
     
     client_dir = resolve_client_dir(client_name)
     tower_dir = client_dir / tower_id
-    blueprint_path = tower_dir / f"blueprint_{tower_id.lower()}_payload.json"
-    output_path = tower_dir / f"approved_annex_{tower_id.lower()}.template_payload.json"
-    client_intelligence_path = client_dir / "client_intelligence.json"
-    case_input_path = tower_dir / "case_input.json"
+    blueprint_path = resolve_blueprint_payload_path(client_name, tower_id)
+    output_path = resolve_annex_template_payload_path(client_name, tower_id)
+    client_intelligence_path = resolve_client_intelligence_path(client_name)
+    case_input_path = resolve_case_input_path(client_name, tower_id)
     radar_chart_path = tower_dir / "pillar_radar_chart.generated.png"
     
     if not blueprint_path.exists():

--- a/src/assessment_engine/scripts/run_global_pipeline.py
+++ b/src/assessment_engine/scripts/run_global_pipeline.py
@@ -2,55 +2,15 @@
 Módulo run_global_pipeline.py.
 Contiene la lógica y utilidades principales para el pipeline de Assessment Engine.
 """
-import os
 import sys
-import importlib
-import asyncio
-from unittest.mock import patch
-from pathlib import Path
-from assessment_engine.scripts.lib.runtime_env import (
-    ensure_google_cloud_env_defaults,
-    run_vertex_ai_preflight,
+
+from assessment_engine.scripts.lib.pipeline_runtime import (
+    build_runtime_env,
+    resolve_python_bin,
+    run_module_step,
 )
-
-ROOT = Path(__file__).resolve().parents[3]
-
-
-def run_step(cmd_args: list[str], step_name: str, env: dict[str, str]) -> None:
-    print(f"\n=== {step_name} ===")
-
-    process_env = os.environ.copy()
-    process_env.update(env)
-    process_env["PYTHONPATH"] = str(ROOT / "src")
-    for k, v in process_env.items():
-        os.environ[k] = v
-
-    if len(cmd_args) >= 3 and cmd_args[1] == "-m":
-        module_name = cmd_args[2]
-        script_args = cmd_args[3:]
-    else:
-        raise ValueError(f"Comando no soportado por run_native_step: {cmd_args}")
-
-    mock_argv = [module_name] + script_args
-    try:
-        with patch.object(sys, 'argv', mock_argv):
-            mod = importlib.import_module(module_name)
-            importlib.reload(mod)
-            if hasattr(mod, 'main'):
-                result = mod.main()
-                if asyncio.iscoroutine(result):
-                    asyncio.run(result)
-            else:
-                raise RuntimeError(f"El módulo {module_name} no tiene función main()")
-    except SystemExit as e:
-        if e.code != 0 and e.code is not None:
-            raise RuntimeError(f"Fallo nativo (SystemExit) en {step_name} con código: {e.code}")
-        else:
-            print(f"[{step_name}] Finalizado con exit(0)")
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        raise RuntimeError(f"Fallo nativo en {step_name} con error: {e}")
+from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
+from assessment_engine.scripts.lib.runtime_paths import ROOT
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -60,9 +20,7 @@ def main(argv: list[str] | None = None) -> None:
 
     client_name = (argv if argv is not None else sys.argv)[1]
     client_dir = ROOT / "working" / client_name
-    env = os.environ.copy()
-    ensure_google_cloud_env_defaults(env)
-    env["PYTHONPATH"] = str(ROOT / "src")
+    env = build_runtime_env()
     if env.get("ASSESSMENT_SKIP_VERTEX_PREFLIGHT", "").strip() != "1":
         preflight = run_vertex_ai_preflight(env=env)
         print(
@@ -79,12 +37,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     output_path = client_dir / f"Informe_Ejecutivo_Consolidado_{client_name}.docx"
 
-    python_bin = str(ROOT / ".venv" / "bin" / "python")
-    if not Path(python_bin).exists():
-        python_bin = sys.executable
+    python_bin = resolve_python_bin()
 
     # 1. Generar Payload Inicial
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.build_global_report_payload",
@@ -97,7 +53,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # 2. Refinado Estratégico con IA (CIO Level)
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.run_executive_refiner",
@@ -108,7 +64,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # 3. Generar Visuales
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.generate_global_radar_chart",
@@ -117,7 +73,7 @@ def main(argv: list[str] | None = None) -> None:
         "Generate Global Radar Chart",
         env,
     )
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.generate_executive_roadmap_image",
@@ -128,7 +84,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # 4. Renderizar DOCX
-    run_step(
+    run_module_step(
         [
             python_bin,
             "-m", "assessment_engine.scripts.render_global_report_from_template",

--- a/src/assessment_engine/scripts/run_global_pipeline.py
+++ b/src/assessment_engine/scripts/run_global_pipeline.py
@@ -10,7 +10,11 @@ from assessment_engine.scripts.lib.pipeline_runtime import (
     run_module_step,
 )
 from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
-from assessment_engine.scripts.lib.runtime_paths import ROOT, resolve_client_dir
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_client_dir,
+    resolve_global_report_payload_path,
+    resolve_global_report_template_path,
+)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -28,13 +32,8 @@ def main(argv: list[str] | None = None) -> None:
             f"(project={preflight['project']}, location={preflight['location']}, model={preflight['model']})"
         )
 
-    payload_path = client_dir / "global_report_payload.json"
-    template_path = (
-        ROOT
-        / "source_docs"
-        / "templates"
-        / "11. Template Documento General Alpha v.05.docx"
-    )
+    payload_path = resolve_global_report_payload_path(client_name)
+    template_path = resolve_global_report_template_path()
     output_path = client_dir / f"Informe_Ejecutivo_Consolidado_{client_name}.docx"
 
     python_bin = resolve_python_bin()

--- a/src/assessment_engine/scripts/run_global_pipeline.py
+++ b/src/assessment_engine/scripts/run_global_pipeline.py
@@ -10,7 +10,7 @@ from assessment_engine.scripts.lib.pipeline_runtime import (
     run_module_step,
 )
 from assessment_engine.scripts.lib.runtime_env import run_vertex_ai_preflight
-from assessment_engine.scripts.lib.runtime_paths import ROOT
+from assessment_engine.scripts.lib.runtime_paths import ROOT, resolve_client_dir
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -19,7 +19,7 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
 
     client_name = (argv if argv is not None else sys.argv)[1]
-    client_dir = ROOT / "working" / client_name
+    client_dir = resolve_client_dir(client_name)
     env = build_runtime_env()
     if env.get("ASSESSMENT_SKIP_VERTEX_PREFLIGHT", "").strip() != "1":
         preflight = run_vertex_ai_preflight(env=env)

--- a/src/assessment_engine/scripts/run_intelligence_harvesting.py
+++ b/src/assessment_engine/scripts/run_intelligence_harvesting.py
@@ -6,23 +6,25 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+
 from google.adk.agents import Agent
 from vertexai.agent_engines import AdkApp
 
-from assessment_engine.scripts.lib.ai_client import run_agent
-from assessment_engine.schemas.intelligence import (
-    RegulatoryHarvest,
-    BusinessHarvest,
-    TechHarvest,
-    ClientDossier
-)
 from assessment_engine.prompts.intelligence_prompts import (
-    get_regulatory_harvester_prompt,
+    get_auditor_harvester_prompt,
     get_business_harvester_prompt,
+    get_regulatory_harvester_prompt,
     get_tech_harvester_prompt,
-    get_auditor_harvester_prompt
 )
-from assessment_engine.scripts.lib.runtime_paths import resolve_client_dir
+from assessment_engine.schemas.intelligence import (
+    BusinessHarvest,
+    ClientDossier,
+    RegulatoryHarvest,
+    TechHarvest,
+)
+from assessment_engine.scripts.lib.ai_client import run_agent
+from assessment_engine.scripts.lib.runtime_paths import resolve_client_intelligence_path
+
 
 async def run_market_intelligence(client_name: str, output_path: Path):
     print(f"\n🔍 Iniciando Inteligencia de Mercado para: {client_name}")
@@ -111,8 +113,7 @@ def main():
         sys.exit(1)
 
     client_name = sys.argv[1]
-    client_dir = resolve_client_dir(client_name)
-    output_path = client_dir / "client_intelligence.json"
+    output_path = resolve_client_intelligence_path(client_name)
 
     asyncio.run(run_market_intelligence(client_name, output_path))
 

--- a/src/assessment_engine/scripts/run_intelligence_harvesting.py
+++ b/src/assessment_engine/scripts/run_intelligence_harvesting.py
@@ -22,9 +22,7 @@ from assessment_engine.prompts.intelligence_prompts import (
     get_tech_harvester_prompt,
     get_auditor_harvester_prompt
 )
-
-ROOT = Path(__file__).resolve().parents[1]
-
+from assessment_engine.scripts.lib.runtime_paths import resolve_client_dir
 
 async def run_market_intelligence(client_name: str, output_path: Path):
     print(f"\n🔍 Iniciando Inteligencia de Mercado para: {client_name}")
@@ -113,7 +111,7 @@ def main():
         sys.exit(1)
 
     client_name = sys.argv[1]
-    client_dir = ROOT / "working" / client_name
+    client_dir = resolve_client_dir(client_name)
     output_path = client_dir / "client_intelligence.json"
 
     asyncio.run(run_market_intelligence(client_name, output_path))

--- a/src/assessment_engine/scripts/run_tower_blueprint_engine.py
+++ b/src/assessment_engine/scripts/run_tower_blueprint_engine.py
@@ -22,6 +22,9 @@ from assessment_engine.prompts.blueprint_prompts import (
     get_closing_orchestrator_prompt
 )
 from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_blueprint_payload_path,
+    resolve_case_input_path,
+    resolve_client_intelligence_path,
     resolve_client_dir,
     resolve_tower_definition_file,
 )
@@ -124,8 +127,8 @@ async def process_pilar_blueprint(
 async def run_tower_blueprint(client_name, tower_id):
     client_dir = resolve_client_dir(client_name)
     tower_dir = client_dir / tower_id
-    case_input_path = tower_dir / "case_input.json"
-    intel_path = client_dir / "client_intelligence.json"
+    case_input_path = resolve_case_input_path(client_name, tower_id)
+    intel_path = resolve_client_intelligence_path(client_name)
 
     if not case_input_path.exists():
         print(f"Error: No se encuentra input para {tower_id}")
@@ -249,7 +252,7 @@ async def run_tower_blueprint(client_name, tower_id):
         ) from val_err
 
     # GUARDAR PAYLOAD
-    output_path = tower_dir / f"blueprint_{tower_id.lower()}_payload.json"
+    output_path = resolve_blueprint_payload_path(client_name, tower_id)
     output_path.write_text(
         json.dumps(final_payload_dict, indent=2, ensure_ascii=False),
         encoding="utf-8-sig",

--- a/src/assessment_engine/scripts/run_tower_blueprint_engine.py
+++ b/src/assessment_engine/scripts/run_tower_blueprint_engine.py
@@ -5,7 +5,6 @@ Contiene la lógica y utilidades principales para el pipeline de Assessment Engi
 import asyncio
 import json
 import sys
-from pathlib import Path
 from assessment_engine.schemas.blueprint import (
     PillarBlueprintDraft, 
     OrchestratorBlueprintDraft, 
@@ -22,8 +21,10 @@ from assessment_engine.prompts.blueprint_prompts import (
     get_critic_prompt,
     get_closing_orchestrator_prompt
 )
-
-ROOT = Path(__file__).resolve().parents[3]
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_client_dir,
+    resolve_tower_definition_file,
+)
 
 def get_default_blueprint_payload(client_name, tower_name, tower_id, intel_data) -> dict:
     """Provee una estructura base completa que cumple con el contrato de BlueprintPayload."""
@@ -121,7 +122,7 @@ async def process_pilar_blueprint(
 
 
 async def run_tower_blueprint(client_name, tower_id):
-    client_dir = ROOT / "working" / client_name
+    client_dir = resolve_client_dir(client_name)
     tower_dir = client_dir / tower_id
     case_input_path = tower_dir / "case_input.json"
     intel_path = client_dir / "client_intelligence.json"
@@ -149,13 +150,7 @@ async def run_tower_blueprint(client_name, tower_id):
 
     # Agrupar respuestas por pilar
     pillars_map = {}
-    tower_def_path = (
-        ROOT
-        / "engine_config"
-        / "towers"
-        / tower_id
-        / f"tower_definition_{tower_id}.json"
-    )
+    tower_def_path = resolve_tower_definition_file(tower_id)
     tower_def = json.loads(tower_def_path.read_text(encoding="utf-8"))
 
     for p in tower_def.get("pillars", []):

--- a/src/assessment_engine/scripts/run_tower_pipeline.py
+++ b/src/assessment_engine/scripts/run_tower_pipeline.py
@@ -20,7 +20,10 @@ from assessment_engine.scripts.lib.pipeline_runtime import (
 from assessment_engine.scripts.lib.runtime_env import (
     run_vertex_ai_preflight,
 )
-from assessment_engine.scripts.lib.runtime_paths import ROOT
+from assessment_engine.scripts.lib.runtime_paths import (
+    resolve_blueprint_payload_path,
+    resolve_tower_annex_template_path,
+)
 
 SKIP_MODE = False
 START_FROM = None
@@ -121,10 +124,7 @@ async def run_pipeline():
 
     annex_stem = f"approved_annex_{tower_id.lower()}"
     payload_path = case_dir / f"{annex_stem}.template_payload.json"
-
-    template_annex_path = (
-        ROOT / "templates" / "Template_Documento_Anexos_Alpha_v06_Tower_Annex_v2_6.docx"
-    )
+    template_annex_path = resolve_tower_annex_template_path()
     output_docx = case_dir / f"annex_{tower_id.lower()}_{client_slug}_final.docx"
 
     # --- FASE 1: PREPARACIÓN DETERMINISTA (SECUENCIAL) ---
@@ -155,7 +155,7 @@ async def run_pipeline():
             "✅ Vertex AI listo "
             f"(project={preflight['project']}, location={preflight['location']}, model={preflight['model']})"
         )
-    blueprint_payload_path = case_dir / f"blueprint_{tower_id.lower()}_payload.json"
+    blueprint_payload_path = resolve_blueprint_payload_path(client_slug, tower_id)
     output_blueprint_docx = case_dir / f"Blueprint_Transformacion_{tower_id}_{client_slug}.docx"
     
     try:

--- a/src/assessment_engine/scripts/run_tower_pipeline.py
+++ b/src/assessment_engine/scripts/run_tower_pipeline.py
@@ -5,20 +5,22 @@ Implementa un orquestador asíncrono basado en un DAG (Directed Acyclic Graph)
 utilizando Subprocesos Asíncronos aislados para evitar Race Conditions de memoria global.
 """
 import argparse
-import os
-import sys
-import unicodedata
 import asyncio
+import os
+import unicodedata
 from pathlib import Path
 
 from assessment_engine.scripts.lib.pipeline_runtime import (
     build_runtime_env,
+    prepare_case_runtime,
+    resolve_ai_step_timeout_seconds,
     resolve_python_bin,
+    validate_runtime_environment,
 )
-from assessment_engine.scripts.lib.runtime_paths import ROOT
 from assessment_engine.scripts.lib.runtime_env import (
     run_vertex_ai_preflight,
 )
+from assessment_engine.scripts.lib.runtime_paths import ROOT
 
 SKIP_MODE = False
 START_FROM = None
@@ -87,43 +89,6 @@ async def run_step_async(cmd_args: list[str], env: dict[str, str], step_name: st
     except Exception as e:
         raise RuntimeError(f"Error crítico lanzando {step_name}: {e}")
 
-
-def validate_runtime_environment(env: dict[str, str]) -> None:
-    missing_vars = [
-        name
-        for name in ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
-        if not env.get(name, "").strip()
-    ]
-    if missing_vars:
-        raise RuntimeError("Falta configuración de entorno para Vertex AI.")
-
-
-def resolve_ai_step_timeout_seconds(
-    env: dict[str, str],
-    step_name: str,
-) -> float | None:
-    if "Engine:" not in step_name and "Refinement" not in step_name:
-        return None
-
-    raw_value = str(env.get("ASSESSMENT_AI_STEP_TIMEOUT_SECONDS", "")).strip()
-    if not raw_value:
-        return None
-
-    try:
-        timeout_seconds = float(raw_value)
-    except ValueError as exc:
-        raise RuntimeError(
-            "ASSESSMENT_AI_STEP_TIMEOUT_SECONDS debe ser un número positivo."
-        ) from exc
-
-    if timeout_seconds <= 0:
-        raise RuntimeError(
-            "ASSESSMENT_AI_STEP_TIMEOUT_SECONDS debe ser mayor que 0."
-        )
-
-    return timeout_seconds
-
-
 async def run_pipeline():
     parser = argparse.ArgumentParser()
     parser.add_argument("--tower", required=True)
@@ -140,14 +105,14 @@ async def run_pipeline():
 
     tower_id = args.tower.upper().strip()
     client_slug = slugify(args.client)
-    case_dir = ROOT / "working" / client_slug / tower_id
-    case_dir.mkdir(parents=True, exist_ok=True)
     python_bin = resolve_python_bin()
 
     env = build_runtime_env()
-    env["ASSESSMENT_CLIENT_ID"] = client_slug
-    env["ASSESSMENT_TOWER_ID"] = tower_id
-    env["ASSESSMENT_CASE_DIR"] = str(case_dir)
+    case_dir = prepare_case_runtime(
+        env,
+        client_id=client_slug,
+        tower_id=tower_id,
+    )
 
     validate_runtime_environment(env)
 
@@ -155,16 +120,12 @@ async def run_pipeline():
     responses_path = str(Path(args.responses_file).resolve())
 
     annex_stem = f"approved_annex_{tower_id.lower()}"
-    assembled_path = case_dir / f"{annex_stem}.generated.json"
-    review_path = case_dir / "global_review.generated.json"
-    refined_path = case_dir / f"{annex_stem}.refined.json"
     payload_path = case_dir / f"{annex_stem}.template_payload.json"
 
     template_annex_path = (
         ROOT / "templates" / "Template_Documento_Anexos_Alpha_v06_Tower_Annex_v2_6.docx"
     )
     output_docx = case_dir / f"annex_{tower_id.lower()}_{client_slug}_final.docx"
-    radar_path = case_dir / "pillar_radar_chart.generated.png"
 
     # --- FASE 1: PREPARACIÓN DETERMINISTA (SECUENCIAL) ---
     await run_step_async(

--- a/src/assessment_engine/scripts/run_tower_pipeline.py
+++ b/src/assessment_engine/scripts/run_tower_pipeline.py
@@ -11,9 +11,12 @@ import unicodedata
 import asyncio
 from pathlib import Path
 
+from assessment_engine.scripts.lib.pipeline_runtime import (
+    build_runtime_env,
+    resolve_python_bin,
+)
 from assessment_engine.scripts.lib.runtime_paths import ROOT
 from assessment_engine.scripts.lib.runtime_env import (
-    ensure_google_cloud_env_defaults,
     run_vertex_ai_preflight,
 )
 
@@ -85,13 +88,6 @@ async def run_step_async(cmd_args: list[str], env: dict[str, str], step_name: st
         raise RuntimeError(f"Error crítico lanzando {step_name}: {e}")
 
 
-def resolve_python_bin() -> str:
-    venv_python = ROOT / ".venv" / "bin" / "python"
-    if venv_python.exists():
-        return str(venv_python)
-    return sys.executable
-
-
 def validate_runtime_environment(env: dict[str, str]) -> None:
     missing_vars = [
         name
@@ -148,9 +144,7 @@ async def run_pipeline():
     case_dir.mkdir(parents=True, exist_ok=True)
     python_bin = resolve_python_bin()
 
-    env = os.environ.copy()
-    ensure_google_cloud_env_defaults(env)
-    env["PYTHONPATH"] = str(ROOT / "src")
+    env = build_runtime_env()
     env["ASSESSMENT_CLIENT_ID"] = client_slug
     env["ASSESSMENT_TOWER_ID"] = tower_id
     env["ASSESSMENT_CASE_DIR"] = str(case_dir)

--- a/src/assessment_engine/scripts/tools/regenerate_smoke_artifacts.py
+++ b/src/assessment_engine/scripts/tools/regenerate_smoke_artifacts.py
@@ -9,10 +9,12 @@ import argparse
 import os
 import shlex
 import subprocess
-import sys
 
+from assessment_engine.scripts.lib.pipeline_runtime import (
+    build_runtime_env,
+    resolve_python_bin,
+)
 from assessment_engine.scripts.lib.runtime_env import (
-    ensure_google_cloud_env_defaults,
     run_vertex_ai_preflight,
 )
 from assessment_engine.scripts.lib.runtime_paths import ROOT
@@ -20,13 +22,6 @@ from assessment_engine.scripts.tools.generate_smoke_data import generate_smoke_i
 
 
 BLUEPRINT_RESUME_STEP = "Engine: Tower Strategic Blueprint"
-
-
-def resolve_python_bin() -> str:
-    venv_python = ROOT / ".venv" / "bin" / "python"
-    if venv_python.exists():
-        return str(venv_python)
-    return sys.executable
 
 
 def run_step(
@@ -73,9 +68,7 @@ def main(argv: list[str] | None = None) -> None:
     tower_id = args.tower.upper().strip()
     python_bin = resolve_python_bin()
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(ROOT / "src")
-    ensure_google_cloud_env_defaults(env)
+    env = build_runtime_env()
     if args.skip_vertex_preflight:
         env["ASSESSMENT_SKIP_VERTEX_PREFLIGHT"] = "1"
     if args.writer_model:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test helpers package marker for CI imports.

--- a/tests/artifact_helpers.py
+++ b/tests/artifact_helpers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require_artifact(path: Path) -> Path:
+    if not path.exists():
+        pytest.skip(f"Missing artifact: {path}")
+    return path
+
+
+def require_artifact_es(path: Path) -> Path:
+    if not path.exists():
+        pytest.skip(f"No se encontró el artefacto: {path}")
+    return path
+
+
+def require_existing_group(
+    candidate_groups: list[tuple[Path, ...]],
+    *,
+    skip_message: str,
+) -> tuple[Path, ...]:
+    for group in candidate_groups:
+        if all(path.exists() for path in group):
+            return group
+    pytest.skip(skip_message, allow_module_level=True)
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8-sig"))

--- a/tests/test_build_tower_annex_template_payload.py
+++ b/tests/test_build_tower_annex_template_payload.py
@@ -1,25 +1,19 @@
 import json
-from pathlib import Path
 
 from assessment_engine.schemas.annex_synthesis import AnnexPayload
 from assessment_engine.scripts.build_tower_annex_template_payload import main
-import pytest
+from tests.artifact_helpers import ROOT, require_artifact_es
 
-
-ROOT = Path(__file__).resolve().parents[1]
 INPUT_PATH = ROOT / "working" / "ivirma" / "T5" / "approved_annex_t5.refined.json"
 
 
 def test_build_tower_annex_template_payload_matches_schema(tmp_path):
-    if not INPUT_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {INPUT_PATH}")
-
     output_path = tmp_path / "approved_annex_t5.template_payload.json"
 
     main(
         [
             "build_tower_annex_template_payload",
-            str(INPUT_PATH),
+            str(require_artifact_es(INPUT_PATH)),
             str(output_path),
             "ivirma",
             "short",

--- a/tests/test_contract_handover.py
+++ b/tests/test_contract_handover.py
@@ -1,22 +1,12 @@
-import json
-from pathlib import Path
 import pytest
-from assessment_engine.schemas.blueprint import BlueprintPayload
+
 from assessment_engine.schemas.annex_synthesis import AnnexPayload
-from assessment_engine.schemas.global_report import GlobalReportPayload
+from assessment_engine.schemas.blueprint import BlueprintPayload
 from assessment_engine.schemas.commercial import CommercialPayload
+from assessment_engine.schemas.global_report import GlobalReportPayload
+from tests.artifact_helpers import ROOT, load_json, require_artifact
 
-ROOT = Path(__file__).resolve().parents[1]
 T5_DIR = ROOT / "working" / "smoke_ivirma" / "T5"
-
-def _load_json(path):
-    with open(path, "r", encoding="utf-8-sig") as f:
-        return json.load(f)
-
-
-def _require_artifact(path: Path) -> None:
-    if not path.exists():
-        pytest.skip(f"Missing artifact: {path}")
 
 
 def _summarize_project_name(name: str) -> str:
@@ -34,9 +24,9 @@ def test_contract_blueprint_to_annex():
     para el sintetizador del Anexo.
     """
     bp_path = T5_DIR / "blueprint_t5_payload.json"
-    _require_artifact(bp_path)
+    bp_path = require_artifact(bp_path)
     
-    bp_data = _load_json(bp_path)
+    bp_data = load_json(bp_path)
     # Validar que el blueprint cumple su propio esquema (con alias)
     bp_payload = BlueprintPayload.model_validate(bp_data)
     
@@ -52,9 +42,9 @@ def test_contract_annex_is_valid_payload():
     requerido por el renderizador Word.
     """
     annex_path = T5_DIR / "approved_annex_t5.template_payload.json"
-    _require_artifact(annex_path)
+    annex_path = require_artifact(annex_path)
     
-    annex_data = _load_json(annex_path)
+    annex_data = load_json(annex_path)
     # Validar integridad estructural y tipos
     annex_payload = AnnexPayload.model_validate(annex_data)
     
@@ -67,11 +57,11 @@ def test_contract_annex_is_valid_payload():
 def test_contract_annex_keeps_blueprint_non_negotiables_aligned():
     blueprint_path = T5_DIR / "blueprint_t5_payload.json"
     annex_path = T5_DIR / "approved_annex_t5.template_payload.json"
-    _require_artifact(blueprint_path)
-    _require_artifact(annex_path)
+    blueprint_path = require_artifact(blueprint_path)
+    annex_path = require_artifact(annex_path)
 
-    bp_data = _load_json(blueprint_path)
-    annex_data = _load_json(annex_path)
+    bp_data = load_json(blueprint_path)
+    annex_data = load_json(annex_path)
 
     blueprint = BlueprintPayload.model_validate(bp_data)
     annex = AnnexPayload.model_validate(annex_data)

--- a/tests/test_document_integrity.py
+++ b/tests/test_document_integrity.py
@@ -1,12 +1,10 @@
+import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
-import zipfile
 
 from docx import Document
-import pytest
 
-
-ROOT = Path(__file__).resolve().parents[1]
+from tests.artifact_helpers import ROOT, require_existing_group
 
 
 def _resolve_t5_docx_pair() -> tuple[Path, Path]:
@@ -30,12 +28,9 @@ def _resolve_t5_docx_pair() -> tuple[Path, Path]:
             / "annex_t5_ivirma_final.docx",
         ),
     ]
-    for blueprint, annex in preferred_pairs:
-        if blueprint.exists() and annex.exists():
-            return blueprint, annex
-    pytest.skip(
-        "No hay artefactos DOCX T5 disponibles en working/ para validar integridad.",
-        allow_module_level=True,
+    return require_existing_group(
+        preferred_pairs,
+        skip_message="No hay artefactos DOCX T5 disponibles en working/ para validar integridad.",
     )
 
 

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -1,21 +1,16 @@
 import pytest
-import json
-from pathlib import Path
 from pydantic import ValidationError
 
-from assessment_engine.schemas.global_report import GlobalReportPayload
 from assessment_engine.schemas.commercial import CommercialPayload
+from assessment_engine.schemas.global_report import GlobalReportPayload
+from tests.artifact_helpers import ROOT, load_json, require_artifact
 
-ROOT = Path(__file__).resolve().parents[1]
 SMOKE_DIR = ROOT / "working" / "smoke_ivirma"
 
 def test_global_report_payload_schema():
     """Valida el esquema del Informe Global contra el payload real generado."""
-    payload_file = SMOKE_DIR / "global_report_payload.json"
-    if not payload_file.exists():
-        pytest.skip("No global_report_payload.json found. Run smoke test first.")
-        
-    data = json.loads(payload_file.read_text(encoding="utf-8"))
+    payload_file = require_artifact(SMOKE_DIR / "global_report_payload.json")
+    data = load_json(payload_file)
     
     try:
         payload = GlobalReportPayload.model_validate(data)
@@ -26,11 +21,8 @@ def test_global_report_payload_schema():
 
 def test_commercial_report_payload_schema():
     """Valida el esquema del Account Action Plan contra el payload real generado."""
-    payload_file = SMOKE_DIR / "commercial_report_payload.json"
-    if not payload_file.exists():
-        pytest.skip("No commercial_report_payload.json found. Run smoke test first.")
-        
-    data = json.loads(payload_file.read_text(encoding="utf-8"))
+    payload_file = require_artifact(SMOKE_DIR / "commercial_report_payload.json")
+    data = load_json(payload_file)
     
     try:
         payload = CommercialPayload.model_validate(data)

--- a/tests/test_pipeline_env_propagation.py
+++ b/tests/test_pipeline_env_propagation.py
@@ -48,7 +48,7 @@ def test_run_global_pipeline_passes_validated_env_to_steps(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         run_global_pipeline,
-        "run_step",
+        "run_module_step",
         lambda _cmd_args, _step_name, env: captured.append(dict(env)),
     )
 
@@ -75,7 +75,7 @@ def test_run_commercial_pipeline_passes_validated_env_to_steps(monkeypatch) -> N
     )
     monkeypatch.setattr(
         run_commercial_pipeline,
-        "run_step",
+        "run_module_step",
         lambda _cmd_args, _step_name, env: captured.append(dict(env)),
     )
 

--- a/tests/test_pipeline_runtime.py
+++ b/tests/test_pipeline_runtime.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from assessment_engine.scripts.lib import pipeline_runtime
+
+
+def test_prepare_case_runtime_sets_case_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        pipeline_runtime,
+        "resolve_client_dir",
+        lambda client_id: tmp_path / "working" / client_id,
+    )
+    env: dict[str, str] = {}
+
+    case_dir = pipeline_runtime.prepare_case_runtime(
+        env,
+        client_id="smoke_ivirma",
+        tower_id="T5",
+    )
+
+    expected_dir = tmp_path / "working" / "smoke_ivirma" / "T5"
+    assert case_dir == expected_dir
+    assert case_dir.exists()
+    assert env["ASSESSMENT_CLIENT_ID"] == "smoke_ivirma"
+    assert env["ASSESSMENT_TOWER_ID"] == "T5"
+    assert env["ASSESSMENT_CASE_DIR"] == str(expected_dir)
+
+
+def test_validate_runtime_environment_requires_vertex_env() -> None:
+    with pytest.raises(RuntimeError, match="Falta configuración de entorno para Vertex AI"):
+        pipeline_runtime.validate_runtime_environment({"GOOGLE_CLOUD_PROJECT": ""})
+
+
+@pytest.mark.parametrize(
+    ("step_name", "expected"),
+    [
+        ("Engine: Tower Strategic Blueprint", 45.0),
+        ("Strategic Executive Refinement", 45.0),
+        ("Build case_input", None),
+    ],
+)
+def test_resolve_ai_step_timeout_seconds_scopes_to_ai_steps(
+    step_name: str,
+    expected: float | None,
+) -> None:
+    env = {"ASSESSMENT_AI_STEP_TIMEOUT_SECONDS": "45"}
+
+    assert pipeline_runtime.resolve_ai_step_timeout_seconds(env, step_name) == expected
+
+
+@pytest.mark.parametrize("raw_value", ["invalid", "0", "-1"])
+def test_resolve_ai_step_timeout_seconds_rejects_invalid_values(raw_value: str) -> None:
+    env = {"ASSESSMENT_AI_STEP_TIMEOUT_SECONDS": raw_value}
+
+    with pytest.raises(RuntimeError, match="ASSESSMENT_AI_STEP_TIMEOUT_SECONDS"):
+        pipeline_runtime.resolve_ai_step_timeout_seconds(
+            env,
+            "Engine: Tower Strategic Blueprint",
+        )

--- a/tests/test_render_commercial_report.py
+++ b/tests/test_render_commercial_report.py
@@ -1,15 +1,11 @@
-from pathlib import Path
-
 from docx import Document
-import pytest
 
 from assessment_engine.scripts.render_commercial_report import (
     load_payload,
     render_commercial_report,
 )
+from tests.artifact_helpers import ROOT, require_artifact_es
 
-
-ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = ROOT / "working" / "ivirma" / "commercial_report_payload.json"
 TEMPLATE_PATH = (
     ROOT / "source_docs" / "templates" / "11. Template Documento General Alpha v.05.docx"
@@ -17,11 +13,8 @@ TEMPLATE_PATH = (
 
 
 def test_render_commercial_report_from_real_payload(tmp_path):
-    if not PAYLOAD_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {PAYLOAD_PATH}")
-
     output_path = tmp_path / "commercial_report_test.docx"
-    payload = load_payload(PAYLOAD_PATH)
+    payload = load_payload(require_artifact_es(PAYLOAD_PATH))
 
     render_commercial_report(
         payload=payload,

--- a/tests/test_render_global_report.py
+++ b/tests/test_render_global_report.py
@@ -1,15 +1,11 @@
-from pathlib import Path
-
 from docx import Document
-import pytest
 
 from assessment_engine.scripts.render_global_report_from_template import (
     load_payload,
     render_global_report,
 )
+from tests.artifact_helpers import ROOT, require_artifact_es
 
-
-ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = ROOT / "working" / "ivirma" / "global_report_payload.json"
 TEMPLATE_PATH = (
     ROOT / "source_docs" / "templates" / "11. Template Documento General Alpha v.05.docx"
@@ -17,11 +13,8 @@ TEMPLATE_PATH = (
 
 
 def test_render_global_report_from_real_payload(tmp_path):
-    if not PAYLOAD_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {PAYLOAD_PATH}")
-
     output_path = tmp_path / "global_report_test.docx"
-    payload = load_payload(PAYLOAD_PATH)
+    payload = load_payload(require_artifact_es(PAYLOAD_PATH))
 
     render_global_report(
         payload=payload,

--- a/tests/test_render_tower_annex.py
+++ b/tests/test_render_tower_annex.py
@@ -1,13 +1,10 @@
-from pathlib import Path
 import zipfile
 
 from docx import Document
-import pytest
 
 from assessment_engine.scripts.render_tower_annex_from_template import main
+from tests.artifact_helpers import ROOT, require_artifact_es
 
-
-ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = (
     ROOT / "working" / "ivirma" / "T5" / "approved_annex_t5.template_payload.json"
 )
@@ -17,15 +14,12 @@ TEMPLATE_PATH = (
 
 
 def test_render_tower_annex_from_real_payload(tmp_path):
-    if not PAYLOAD_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {PAYLOAD_PATH}")
-
     output_path = tmp_path / "annex_t5_test.docx"
 
     main(
         [
             "render_tower_annex_from_template",
-            str(PAYLOAD_PATH),
+            str(require_artifact_es(PAYLOAD_PATH)),
             str(TEMPLATE_PATH),
             str(output_path),
         ]
@@ -41,15 +35,12 @@ def test_render_tower_annex_from_real_payload(tmp_path):
 
 
 def test_render_tower_annex_semantic_mode_uses_word_styles(tmp_path):
-    if not PAYLOAD_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {PAYLOAD_PATH}")
-
     output_path = tmp_path / "annex_t5_semantic.docx"
 
     main(
         [
             "render_tower_annex_from_template",
-            str(PAYLOAD_PATH),
+            str(require_artifact_es(PAYLOAD_PATH)),
             str(TEMPLATE_PATH),
             str(output_path),
             "--semantic-styles",

--- a/tests/test_render_tower_blueprint.py
+++ b/tests/test_render_tower_blueprint.py
@@ -1,27 +1,20 @@
-from pathlib import Path
-
 from docx import Document
-import pytest
 
 from assessment_engine.scripts.render_tower_blueprint import (
     load_annex_data,
     load_payload,
     render_blueprint,
 )
+from tests.artifact_helpers import ROOT, require_artifact_es
 
-
-ROOT = Path(__file__).resolve().parents[1]
 CLIENT_DIR = ROOT / "working" / "ivirma"
 PAYLOAD_PATH = CLIENT_DIR / "T5" / "blueprint_t5_payload.json"
 
 
 def test_render_tower_blueprint_from_real_payload(tmp_path):
-    if not PAYLOAD_PATH.exists():
-        pytest.skip(f"No se encontró el artefacto: {PAYLOAD_PATH}")
-
     output_path = tmp_path / "tower_blueprint_test.docx"
     annex_data = load_annex_data(CLIENT_DIR, "T5")
-    payload = load_payload(PAYLOAD_PATH, annex_data=annex_data)
+    payload = load_payload(require_artifact_es(PAYLOAD_PATH), annex_data=annex_data)
 
     render_blueprint(
         payload=payload,

--- a/tests/test_render_tower_blueprint.py
+++ b/tests/test_render_tower_blueprint.py
@@ -1,7 +1,10 @@
+import json
+
 from docx import Document
 
 from assessment_engine.scripts.render_tower_blueprint import (
     load_annex_data,
+    load_client_intelligence,
     load_payload,
     render_blueprint,
 )
@@ -30,3 +33,21 @@ def test_render_tower_blueprint_from_real_payload(tmp_path):
     assert "Informe de Madurez Tecnológica" in text_content
     assert "Resumen ejecutivo" in text_content
     assert "Capacidad:" in text_content
+
+
+def test_render_tower_blueprint_uses_payload_adjacent_artifacts(tmp_path):
+    client_dir = tmp_path / "exported-client"
+    tower_dir = client_dir / "T5"
+    tower_dir.mkdir(parents=True)
+
+    (client_dir / "client_intelligence.json").write_text(
+        json.dumps({"financial_tier": "Tier X"}),
+        encoding="utf-8",
+    )
+    (tower_dir / "approved_annex_t5.template_payload.json").write_text(
+        json.dumps({"executive_summary": {"headline": "Adjunto"}}),
+        encoding="utf-8",
+    )
+
+    assert load_client_intelligence(client_dir)["financial_tier"] == "Tier X"
+    assert load_annex_data(client_dir, "T5")["executive_summary"]["headline"] == "Adjunto"

--- a/tests/test_render_web_presentation.py
+++ b/tests/test_render_web_presentation.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
+
 import pytest
-from unittest.mock import patch
 
 from assessment_engine.scripts.render_web_presentation import generate_web_dashboard
 

--- a/tests/test_run_intelligence_harvesting.py
+++ b/tests/test_run_intelligence_harvesting.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from assessment_engine.scripts import run_intelligence_harvesting
+
+
+def test_main_uses_runtime_client_dir(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", ["run_intelligence_harvesting.py", "smoke_ivirma"])
+    monkeypatch.setattr(
+        run_intelligence_harvesting,
+        "resolve_client_dir",
+        lambda client_name: Path("/tmp/runtime-working") / client_name,
+    )
+    monkeypatch.setattr(
+        run_intelligence_harvesting,
+        "run_market_intelligence",
+        lambda client_name, output_path: captured.update(
+            {"client_name": client_name, "output_path": output_path}
+        ),
+    )
+    monkeypatch.setattr(
+        run_intelligence_harvesting.asyncio,
+        "run",
+        lambda result: result,
+    )
+
+    run_intelligence_harvesting.main()
+
+    assert captured["client_name"] == "smoke_ivirma"
+    assert captured["output_path"] == Path(
+        "/tmp/runtime-working/smoke_ivirma/client_intelligence.json"
+    )

--- a/tests/test_run_intelligence_harvesting.py
+++ b/tests/test_run_intelligence_harvesting.py
@@ -12,8 +12,8 @@ def test_main_uses_runtime_client_dir(monkeypatch) -> None:
     monkeypatch.setattr(sys, "argv", ["run_intelligence_harvesting.py", "smoke_ivirma"])
     monkeypatch.setattr(
         run_intelligence_harvesting,
-        "resolve_client_dir",
-        lambda client_name: Path("/tmp/runtime-working") / client_name,
+        "resolve_client_intelligence_path",
+        lambda client_name: Path("/tmp/runtime-working") / client_name / "client_intelligence.json",
     )
     monkeypatch.setattr(
         run_intelligence_harvesting,

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -23,6 +23,23 @@ def test_resolve_client_dir_prefers_environment_client(monkeypatch) -> None:
     assert client_dir == Path("/tmp/assessment-engine/working/env-client")
 
 
+def test_resolve_client_dir_falls_back_to_legacy_working(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.delenv("ASSESSMENT_CLIENT_ID", raising=False)
+    monkeypatch.setattr(
+        Path,
+        "exists",
+        lambda self: str(self)
+        == "/tmp/assessment-engine/src/assessment_engine/working/smoke_ivirma",
+    )
+
+    client_dir = runtime_paths.resolve_client_dir("smoke_ivirma")
+
+    assert client_dir == Path(
+        "/tmp/assessment-engine/src/assessment_engine/working/smoke_ivirma"
+    )
+
+
 def test_resolve_case_dir_uses_client_helper(monkeypatch) -> None:
     monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
     monkeypatch.delenv("ASSESSMENT_CASE_DIR", raising=False)
@@ -32,3 +49,58 @@ def test_resolve_case_dir_uses_client_helper(monkeypatch) -> None:
     case_dir = runtime_paths.resolve_case_dir("smoke_ivirma", "T5")
 
     assert case_dir == Path("/tmp/assessment-engine/working/smoke_ivirma/T5")
+
+
+def test_resolve_artifact_paths(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.delenv("ASSESSMENT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ASSESSMENT_TOWER_ID", raising=False)
+
+    assert runtime_paths.resolve_client_intelligence_path("smoke_ivirma") == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/client_intelligence.json"
+    )
+    assert runtime_paths.resolve_global_report_payload_path("smoke_ivirma") == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/global_report_payload.json"
+    )
+    assert runtime_paths.resolve_commercial_report_payload_path("smoke_ivirma") == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/commercial_report_payload.json"
+    )
+    assert runtime_paths.resolve_case_input_path("smoke_ivirma", "T5") == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/T5/case_input.json"
+    )
+    assert runtime_paths.resolve_blueprint_payload_path("smoke_ivirma", "T5") == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/T5/blueprint_t5_payload.json"
+    )
+    assert runtime_paths.resolve_annex_template_payload_path(
+        "smoke_ivirma",
+        "T5",
+    ) == Path(
+        "/tmp/assessment-engine/working/smoke_ivirma/T5/approved_annex_t5.template_payload.json"
+    )
+
+
+def test_resolve_blueprint_payload_candidates_include_uppercase_legacy(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.delenv("ASSESSMENT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ASSESSMENT_TOWER_ID", raising=False)
+
+    candidates = runtime_paths.resolve_blueprint_payload_candidates("smoke_ivirma", "T1")
+
+    assert candidates == (
+        Path("/tmp/assessment-engine/working/smoke_ivirma/T1/blueprint_t1_payload.json"),
+        Path("/tmp/assessment-engine/working/smoke_ivirma/T1/blueprint_T1_payload.json"),
+    )
+
+
+def test_resolve_template_paths(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+
+    assert runtime_paths.resolve_global_report_template_path() == Path(
+        "/tmp/assessment-engine/source_docs/templates/11. Template Documento General Alpha v.05.docx"
+    )
+    assert runtime_paths.resolve_tower_annex_template_path() == Path(
+        "/tmp/assessment-engine/templates/Template_Documento_Anexos_Alpha_v06_Tower_Annex_v2_6.docx"
+    )
+    assert runtime_paths.resolve_web_dashboard_template_path() == Path(
+        "/tmp/assessment-engine/src/assessment_engine/templates/web_dashboard.html"
+    )

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from assessment_engine.scripts.lib import runtime_paths
+
+
+def test_resolve_client_dir_uses_default_client(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.delenv("ASSESSMENT_CLIENT_ID", raising=False)
+
+    client_dir = runtime_paths.resolve_client_dir("smoke_ivirma")
+
+    assert client_dir == Path("/tmp/assessment-engine/working/smoke_ivirma")
+
+
+def test_resolve_client_dir_prefers_environment_client(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.setenv("ASSESSMENT_CLIENT_ID", "env-client")
+
+    client_dir = runtime_paths.resolve_client_dir("fallback-client")
+
+    assert client_dir == Path("/tmp/assessment-engine/working/env-client")
+
+
+def test_resolve_case_dir_uses_client_helper(monkeypatch) -> None:
+    monkeypatch.setattr(runtime_paths, "ROOT", Path("/tmp/assessment-engine"))
+    monkeypatch.delenv("ASSESSMENT_CASE_DIR", raising=False)
+    monkeypatch.delenv("ASSESSMENT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ASSESSMENT_TOWER_ID", raising=False)
+
+    case_dir = runtime_paths.resolve_case_dir("smoke_ivirma", "T5")
+
+    assert case_dir == Path("/tmp/assessment-engine/working/smoke_ivirma/T5")

--- a/tests/test_t5_golden.py
+++ b/tests/test_t5_golden.py
@@ -1,33 +1,20 @@
 import hashlib
-import json
 import zipfile
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
-import pytest
 from docx import Document
 
 from assessment_engine.schemas.annex_synthesis import AnnexPayload
 from assessment_engine.schemas.blueprint import BlueprintPayload
+from tests.artifact_helpers import ROOT, load_json, require_artifact
 
-
-ROOT = Path(__file__).resolve().parents[1]
 T5_DIR = ROOT / "working" / "smoke_ivirma" / "T5"
 BLUEPRINT_PAYLOAD = T5_DIR / "blueprint_t5_payload.json"
 ANNEX_PAYLOAD = T5_DIR / "approved_annex_t5.template_payload.json"
 BLUEPRINT_DOCX = T5_DIR / "Blueprint_Transformacion_T5_smoke_ivirma.docx"
 ANNEX_DOCX = T5_DIR / "annex_t5_smoke_ivirma_final.docx"
 RADAR_PNG = T5_DIR / "pillar_radar_chart.generated.png"
-
-
-def _require(path: Path) -> Path:
-    if not path.exists():
-        pytest.skip(f"Missing artifact: {path}")
-    return path
-
-
-def _load_json(path: Path):
-    return json.loads(path.read_text(encoding="utf-8-sig"))
 
 
 def _docx_xml_and_rels(path: Path):
@@ -58,7 +45,7 @@ def _sha256_file(path: Path) -> str:
 
 
 def test_t5_blueprint_payload_schema_and_shape():
-    data = _load_json(_require(BLUEPRINT_PAYLOAD))
+    data = load_json(require_artifact(BLUEPRINT_PAYLOAD))
     payload = BlueprintPayload.model_validate(data)
     assert payload.document_meta.tower_code == "T5"
     assert payload.document_meta.tower_name == "Resilience & Continuity"
@@ -71,7 +58,7 @@ def test_t5_blueprint_payload_schema_and_shape():
 
 
 def test_t5_annex_payload_schema_and_executive_limits():
-    data = _load_json(_require(ANNEX_PAYLOAD))
+    data = load_json(require_artifact(ANNEX_PAYLOAD))
     payload = AnnexPayload.model_validate(data)
     assert payload.document_meta["tower_code"] == "T5"
     assert payload.document_meta["tower_name"] == "Resilience & Continuity"
@@ -94,7 +81,7 @@ def test_t5_annex_payload_schema_and_executive_limits():
 
 
 def test_t5_annex_docx_has_no_functional_placeholders():
-    xml, _ = _docx_xml_and_rels(_require(ANNEX_DOCX))
+    xml, _ = _docx_xml_and_rels(require_artifact(ANNEX_DOCX))
     forbidden = [
         "{{RISKS_TABLE}}",
         "{{GAP_TABLE}}",
@@ -110,8 +97,8 @@ def test_t5_annex_docx_has_no_functional_placeholders():
 
 
 def test_t5_annex_docx_embeds_real_radar_chart():
-    annex_path = _require(ANNEX_DOCX)
-    radar_path = _require(RADAR_PNG)
+    annex_path = require_artifact(ANNEX_DOCX)
+    radar_path = require_artifact(RADAR_PNG)
     with zipfile.ZipFile(annex_path) as zf:
         document = ET.fromstring(zf.read("word/document.xml"))
         rels = ET.fromstring(zf.read("word/_rels/document.xml.rels"))
@@ -145,15 +132,15 @@ def test_t5_annex_docx_embeds_real_radar_chart():
 
 
 def test_t5_blueprint_and_annex_roles_are_distinct():
-    blueprint_words = _docx_words(_require(BLUEPRINT_DOCX))
-    annex_words = _docx_words(_require(ANNEX_DOCX))
+    blueprint_words = _docx_words(require_artifact(BLUEPRINT_DOCX))
+    annex_words = _docx_words(require_artifact(ANNEX_DOCX))
     assert blueprint_words > annex_words
     assert annex_words < 5000
     assert blueprint_words > 7000
 
 
 def test_t5_blueprint_opening_contains_business_layer():
-    doc = Document(_require(BLUEPRINT_DOCX))
+    doc = Document(require_artifact(BLUEPRINT_DOCX))
     text = "\n".join(p.text for p in doc.paragraphs if p.text.strip())
     assert "Por qué importa al negocio" in text
     assert "Riesgos de negocio más materiales" in text


### PR DESCRIPTION
## Summary
- reduce duplication in artifact-dependent tests
- centralize shared runtime bootstrap and working path resolution
- centralize artifact/template path helpers across tower, global, commercial, and web flows

## Validation
- .venv/bin/python -m ruff check src/assessment_engine/scripts/lib/runtime_paths.py src/assessment_engine/scripts/build_case_input.py src/assessment_engine/scripts/run_global_pipeline.py src/assessment_engine/scripts/run_commercial_pipeline.py src/assessment_engine/scripts/run_intelligence_harvesting.py src/assessment_engine/scripts/render_web_presentation.py src/assessment_engine/scripts/run_tower_pipeline.py tests/test_runtime_paths.py tests/test_run_intelligence_harvesting.py tests/test_render_web_presentation.py
- .venv/bin/python -m pytest tests/test_runtime_paths.py tests/test_run_intelligence_harvesting.py tests/test_pipeline_runtime.py tests/test_pipeline_env_propagation.py tests/test_render_web_presentation.py -q
- .venv/bin/python -m pytest tests/ -q