### PR TITLE
feat: Unifica la traducción de score a banda de madurez entre artefactos

### DIFF
--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -934,6 +934,27 @@ entries:
     last_verified_against: 2026-05-01
     notes: Helper compartido para score, banda, color y target del dominio global, usado para evitar duplicaciones semánticas entre builder y renderizadores.
 
+  - path: src/assessment_engine/scripts/lib/maturity_band.py
+    kind: document
+    title: Shared maturity band policy helper
+    doc_type: operational
+    status: Verified
+    owner: docs-governance
+    applies_to:
+      - humans
+      - ai-agents
+    source_of_truth:
+      - docs/operations/engineering-quality-gates.md
+      - src/assessment_engine/scripts/run_scoring.py
+      - src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+      - src/assessment_engine/scripts/render_tower_blueprint.py
+      - src/assessment_engine/scripts/build_global_report_payload.py
+      - src/assessment_engine/scripts/render_web_presentation.py
+      - tests/test_maturity_band.py
+      - tests/test_maturity_band_characterization.py
+    last_verified_against: 2026-05-01
+    notes: Fuente única de verdad para traducir score numérico a banda cualitativa en scoring, annex, blueprint, global y web.
+
   - path: GEMINI.md
     kind: document
     title: Gemini adapter and operating memory

--- a/docs/operations/assessment-coherence-remediation.md
+++ b/docs/operations/assessment-coherence-remediation.md
@@ -70,12 +70,14 @@ Con un score medio-alto y un target cercano, esa narrativa no resulta proporcion
 
 ### 1. Doble sistema de bandas de madurez
 
-Hay al menos dos fuentes distintas para traducir score a banda cualitativa:
+Originalmente había al menos dos fuentes distintas para traducir score a banda cualitativa:
 
 1. `run_scoring.py` usa `score_bands` definidos por torre en `engine_config/towers/*/tower_definition_*.json`.
 2. `run_executive_annex_synthesizer.py` usa `derive_maturity_band()` con umbrales hardcodeados y etiquetas diferentes.
 
-Consecuencia: un mismo score puede tener dos lecturas cualitativas distintas según el artefacto.
+Consecuencia: un mismo score podía tener dos lecturas cualitativas distintas según el artefacto.
+
+**Estado 2026-05-01:** la resolución `score -> banda` quedó centralizada en `src/assessment_engine/scripts/lib/maturity_band.py` y ya es consumida por scoring, annex, blueprint, global y web. Esta pieza mantiene el diagnóstico histórico y el resto de remediaciones abiertas.
 
 ### 2. T3 ya demuestra la inconsistencia
 
@@ -479,6 +481,8 @@ Incluye:
 
 **Retorno de valor:** muy alto.  
 **Por qué va primero:** una sola corrección aquí limpia annex, blueprint, global y dashboard a la vez.
+
+**Estado 2026-05-01:** completado para la traducción de `score -> banda`; siguen abiertas las remediaciones sobre color, target, severidad y tono.
 
 #### P0.2 Corregir la política de target maturity
 

--- a/docs/operations/engineering-quality-gates.md
+++ b/docs/operations/engineering-quality-gates.md
@@ -74,7 +74,7 @@ El objetivo de esta capa no es exigir ahora un repo 100% tipado, sino impedir qu
 
 Las reglas transversales de score, banda, color y target no deben quedar duplicadas entre builder, renderizadores y dashboard.
 
-La política compartida vive ahora en `src/assessment_engine/scripts/lib/global_maturity_policy.py`, y la suite incluye tests de coherencia (`tests/test_global_coherence.py`) para bloquear derivas entre:
+La resolución compartida de bandas vive ahora en `src/assessment_engine/scripts/lib/maturity_band.py`. `run_scoring.py`, `run_executive_annex_synthesizer.py`, `render_tower_blueprint.py`, `build_global_report_payload.py` y `render_web_presentation.py` consumen esa utilidad sin redefinir umbrales locales, mientras que `src/assessment_engine/scripts/lib/global_maturity_policy.py` la reutiliza para la política global. La suite incluye tests de coherencia (`tests/test_global_coherence.py`) para bloquear derivas entre:
 
 - blueprints;
 - payload global;

--- a/src/assessment_engine/scripts/build_global_report_payload.py
+++ b/src/assessment_engine/scripts/build_global_report_payload.py
@@ -17,8 +17,11 @@ from assessment_engine.scripts.lib.client_intelligence import (
 from assessment_engine.scripts.lib.global_maturity_policy import (
     average_pillar_score,
     average_pillar_target,
-    band_for_score,
     status_color_for_score,
+)
+from assessment_engine.scripts.lib.maturity_band import (
+    GLOBAL_MATURITY_BANDS,
+    resolve_maturity_band,
 )
 
 TOWER_NAMES_MAP = {
@@ -99,7 +102,10 @@ def build_global_payload(client_dir: Path, client_name: str) -> dict[str, Any] |
                 "id": tid,
                 "name": tname,
                 "score": f"{avg_score:.1f}",
-                "band": band_for_score(avg_score),
+                "band": resolve_maturity_band(
+                    avg_score,
+                    GLOBAL_MATURITY_BANDS,
+                )["label"],
                 "status_color": status_color_for_score(avg_score),
                 "executive_message": data.get("executive_snapshot", {}).get(
                     "bottom_line", ""

--- a/src/assessment_engine/scripts/lib/global_maturity_policy.py
+++ b/src/assessment_engine/scripts/lib/global_maturity_policy.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from assessment_engine.scripts.lib.maturity_band import (
+    GLOBAL_MATURITY_BANDS,
+    resolve_maturity_band,
+)
+
 LOW_MATURITY_COLOR = "E06666"
 MEDIUM_MATURITY_COLOR = "FFD966"
 HIGH_MATURITY_COLOR = "93C47D"
@@ -49,7 +54,7 @@ def average_pillar_target(
 
 
 def band_for_score(score: float) -> str:
-    return "Optimizada" if score >= 3.5 else "Básica"
+    return resolve_maturity_band(score, GLOBAL_MATURITY_BANDS)["label"]
 
 
 def status_color_for_score(score: float) -> str:

--- a/src/assessment_engine/scripts/lib/maturity_band.py
+++ b/src/assessment_engine/scripts/lib/maturity_band.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TypedDict
+
+
+class MaturityBandDefinition(TypedDict):
+    min: float
+    max: float
+    label: str
+
+
+ANNEX_MATURITY_BANDS: tuple[MaturityBandDefinition, ...] = (
+    {"min": 4.5, "max": float("inf"), "label": "Optimizado"},
+    {"min": 3.5, "max": 4.5, "label": "Gestionado"},
+    {"min": 2.5, "max": 3.5, "label": "Definido"},
+    {"min": 1.5, "max": 2.5, "label": "Repetible"},
+    {"min": float("-inf"), "max": 1.5, "label": "Inicial"},
+)
+
+GLOBAL_MATURITY_BANDS: tuple[MaturityBandDefinition, ...] = (
+    {"min": 3.5, "max": float("inf"), "label": "Optimizada"},
+    {"min": float("-inf"), "max": 3.5, "label": "Básica"},
+)
+
+
+def resolve_maturity_band(
+    score: float,
+    bands: Iterable[MaturityBandDefinition],
+    *,
+    score_precision: int | None = None,
+) -> MaturityBandDefinition:
+    band_list = tuple(bands)
+    if not band_list:
+        raise ValueError("At least one maturity band is required.")
+
+    normalized_score = (
+        round(score, score_precision) if score_precision is not None else score
+    )
+
+    for band in band_list:
+        if band["min"] <= normalized_score <= band["max"]:
+            return band
+
+    return band_list[-1]
+
+
+__all__ = [
+    "ANNEX_MATURITY_BANDS",
+    "GLOBAL_MATURITY_BANDS",
+    "MaturityBandDefinition",
+    "resolve_maturity_band",
+]

--- a/src/assessment_engine/scripts/render_tower_blueprint.py
+++ b/src/assessment_engine/scripts/render_tower_blueprint.py
@@ -13,6 +13,9 @@ from docx.oxml import OxmlElement, ns
 from docx.shared import Inches, Pt, RGBColor
 
 from assessment_engine.schemas.blueprint import BlueprintPayload, PillarBlueprintDraft
+from assessment_engine.scripts.lib.client_intelligence import (
+    load_client_intelligence_legacy_view,
+)
 from assessment_engine.scripts.lib.docx_render_utils import (
     add_body_paragraph as _orig_add_body_paragraph,
 )
@@ -24,11 +27,12 @@ from assessment_engine.scripts.lib.docx_render_utils import (
     set_cell_text,
     shade_cell,
 )
+from assessment_engine.scripts.lib.maturity_band import (
+    ANNEX_MATURITY_BANDS,
+    resolve_maturity_band,
+)
 from assessment_engine.scripts.lib.runtime_paths import (
     resolve_tower_annex_template_path,
-)
-from assessment_engine.scripts.lib.client_intelligence import (
-    load_client_intelligence_legacy_view,
 )
 from assessment_engine.scripts.lib.text_utils import clean_text_for_word
 
@@ -52,6 +56,22 @@ def clean_text_for_render(text):
             return f"{text['name']}: {text['description']}"
         return " - ".join(str(v) for v in text.values())
     return clean_text_for_word(text)
+
+
+def _safe_float(value: object) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(str(value).split()[0].replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_annex_band(value: object) -> str:
+    score = _safe_float(value)
+    if score is None:
+        return ""
+    return resolve_maturity_band(score, ANNEX_MATURITY_BANDS)["label"]
 
 
 def add_body_paragraph(doc, text, color_rgb=BASE_TEXT_COLOR):
@@ -142,7 +162,7 @@ def create_page_number_footer(section):
     add_field(paragraph, "NUMPAGES")
 
 
-def clear_document_body(doc: Document) -> None:
+def clear_document_body(doc) -> None:
     body = doc._body._element
     for child in list(body):
         if (
@@ -221,11 +241,10 @@ def _derive_executive_snapshot(data: dict, annex_data: dict) -> dict:
         "business_impact": _string_or_default(snapshot.get("business_impact"))
         or "La modernización de la torre reduce exposición al riesgo y mejora la capacidad de ejecución del negocio.",
         "operational_benefits": _list_or_default(snapshot.get("operational_benefits"))
-        or [
-            clean_text_for_render(item)
-            for item in target_capabilities[:4]
-        ],
-        "transformation_complexity": _string_or_default(snapshot.get("transformation_complexity"))
+        or [clean_text_for_render(item) for item in target_capabilities[:4]],
+        "transformation_complexity": _string_or_default(
+            snapshot.get("transformation_complexity")
+        )
         or "La transformación exige coordinación de arquitectura, operación y gobierno, pero es abordable por fases.",
     }
 
@@ -234,9 +253,7 @@ def _derive_cross_capabilities_analysis(data: dict) -> dict:
     cca = data.get("cross_capabilities_analysis") or {}
     pillars = _list_or_default(data.get("pillars_analysis"))
     low_score_pillars = [
-        p.get("pilar_name", "")
-        for p in pillars
-        if float(p.get("score", 0) or 0) < 3.0
+        p.get("pilar_name", "") for p in pillars if float(p.get("score", 0) or 0) < 3.0
     ]
 
     if cca:
@@ -257,12 +274,16 @@ def _derive_cross_capabilities_analysis(data: dict) -> dict:
     deficiency_patterns = []
     if low_score_pillars:
         deficiency_patterns.append(
-            "Las mayores brechas se concentran en: " + ", ".join(low_score_pillars) + "."
+            "Las mayores brechas se concentran en: "
+            + ", ".join(low_score_pillars)
+            + "."
         )
 
     return {
         "common_deficiency_patterns": deficiency_patterns
-        or ["Persisten carencias repetidas en estandarización, automatización y gobierno técnico."],
+        or [
+            "Persisten carencias repetidas en estandarización, automatización y gobierno técnico."
+        ],
         "transformation_paradigm": "La transformación debe ejecutarse de forma incremental, combinando quick wins con capacidades fundacionales de largo recorrido.",
         "critical_technical_debt": "La deuda técnica acumulada incrementa el riesgo operativo y reduce la velocidad de adopción de nuevos servicios.",
     }
@@ -297,7 +318,9 @@ def _derive_roadmap(data: dict) -> list[dict]:
 def normalize_blueprint_payload_dict(data: dict, annex_data: dict) -> dict:
     normalized = dict(data)
     normalized["executive_snapshot"] = _derive_executive_snapshot(data, annex_data)
-    normalized["cross_capabilities_analysis"] = _derive_cross_capabilities_analysis(data)
+    normalized["cross_capabilities_analysis"] = _derive_cross_capabilities_analysis(
+        data
+    )
     normalized["roadmap"] = _derive_roadmap(data)
     normalized["external_dependencies"] = _list_or_default(
         data.get("external_dependencies")
@@ -306,7 +329,9 @@ def normalize_blueprint_payload_dict(data: dict, annex_data: dict) -> dict:
     return normalized
 
 
-def load_payload(payload_path: Path, annex_data: dict | None = None) -> BlueprintPayload:
+def load_payload(
+    payload_path: Path, annex_data: dict | None = None
+) -> BlueprintPayload:
     raw_data = load_json(payload_path)
     normalized_data = normalize_blueprint_payload_dict(raw_data, annex_data or {})
     return BlueprintPayload.model_validate(normalized_data)
@@ -331,8 +356,7 @@ def render_cover(doc, payload: BlueprintPayload):
     doc.add_paragraph().paragraph_format.space_after = Pt(100)
     version_p = doc.add_paragraph()
     version_text = (
-        f"Torre Técnica: {meta.tower_code}\n"
-        f"Horizonte: {meta.transformation_horizon}"
+        f"Torre Técnica: {meta.tower_code}\nHorizonte: {meta.transformation_horizon}"
     )
     version_run = version_p.add_run(version_text)
     version_run.font.size = Pt(14)
@@ -364,7 +388,9 @@ def render_snapshot_page(
     snap = payload.executive_snapshot
     exec_sum = annex_data.get("executive_summary", {})
     global_score_val = exec_sum.get("global_score", "N/A")
-    global_band_val = exec_sum.get("global_band", "N/A")
+    global_band_val = exec_sum.get("global_band") or _resolve_annex_band(
+        global_score_val
+    )
     target_score_val = exec_sum.get("target_maturity", "N/A")
 
     add_heading_paragraph(doc, "1. Executive Snapshot (Resumen ejecutivo)", level=1)
@@ -372,7 +398,7 @@ def render_snapshot_page(
     table = doc.add_table(rows=2, cols=3)
     finalize_table(table)
     headers = ["SCORE ACTUAL", "NIVEL DE MADUREZ", "MADUREZ OBJETIVO"]
-    values = [global_score_val, global_band_val, target_score_val]
+    values = [global_score_val, global_band_val or "N/A", target_score_val]
 
     for i, header in enumerate(headers):
         set_cell_text(
@@ -510,7 +536,9 @@ def render_pilar_detail(doc, pilar: PillarBlueprintDraft):
     add_spacer(doc, 10)
 
     add_heading_paragraph(doc, "B. Arquitectura Objetivo (TO-BE)", level=2)
-    add_body_paragraph(doc, pilar.target_architecture_tobe.vision, color_rgb=BASE_TEXT_COLOR)
+    add_body_paragraph(
+        doc, pilar.target_architecture_tobe.vision, color_rgb=BASE_TEXT_COLOR
+    )
     principles = doc.add_paragraph()
     principles_run = principles.add_run("Principios de Diseño:")
     principles_run.bold = True
@@ -532,14 +560,19 @@ def render_pilar_detail(doc, pilar: PillarBlueprintDraft):
         rows = [
             ("Business Rationale", project.expected_outcome),
             ("Objetivo Técnico", project.objective),
-            ("Entregables (DoD)", "\n".join([f"• {item}" for item in project.deliverables])),
+            (
+                "Entregables (DoD)",
+                "\n".join([f"• {item}" for item in project.deliverables]),
+            ),
             (
                 "Sizing & Duración",
                 f"Complejidad: {project.sizing} | Estimación: {project.duration}",
             ),
         ]
         for idx, (label, value) in enumerate(rows, 1):
-            set_cell_text(project_table.rows[idx].cells[0], label, bold=True, font_size=9)
+            set_cell_text(
+                project_table.rows[idx].cells[0], label, bold=True, font_size=9
+            )
             shade_cell(project_table.rows[idx].cells[0], "F2F2F2")
             set_cell_text(project_table.rows[idx].cells[1], value, font_size=9.5)
             for run in project_table.rows[idx].cells[1].paragraphs[0].runs:
@@ -621,15 +654,22 @@ def render_maturity_profile(doc, annex_data: dict):
 
         for pillar in pillars:
             row = table.add_row()
-            set_cell_text(row.cells[0], pillar.get("pillar_label", ""), bold=True, font_size=9.5)
+            maturity_band = pillar.get("maturity_band") or _resolve_annex_band(
+                pillar.get("score_display")
+            )
+            set_cell_text(
+                row.cells[0], pillar.get("pillar_label", ""), bold=True, font_size=9.5
+            )
             set_cell_text(
                 row.cells[1],
                 pillar.get("score_display", ""),
                 font_size=9.5,
                 align=WD_ALIGN_PARAGRAPH.CENTER,
             )
-            set_cell_text(row.cells[2], pillar.get("maturity_band", ""), font_size=9.5)
-            set_cell_text(row.cells[3], pillar.get("executive_reading", ""), font_size=9.5)
+            set_cell_text(row.cells[2], maturity_band, font_size=9.5)
+            set_cell_text(
+                row.cells[3], pillar.get("executive_reading", ""), font_size=9.5
+            )
             for cell in row.cells:
                 for paragraph in cell.paragraphs:
                     for run in paragraph.runs:
@@ -645,9 +685,13 @@ def render_maturity_profile(doc, annex_data: dict):
     if strengths or gaps:
         sg_table = doc.add_table(rows=2, cols=2)
         finalize_table(sg_table)
-        set_cell_text(sg_table.rows[0].cells[0], "Fortalezas clave", bold=True, font_size=10)
+        set_cell_text(
+            sg_table.rows[0].cells[0], "Fortalezas clave", bold=True, font_size=10
+        )
         shade_cell(sg_table.rows[0].cells[0], "D9EAF7")
-        set_cell_text(sg_table.rows[0].cells[1], "Brechas clave", bold=True, font_size=10)
+        set_cell_text(
+            sg_table.rows[0].cells[1], "Brechas clave", bold=True, font_size=10
+        )
         shade_cell(sg_table.rows[0].cells[1], "D9EAF7")
 
         strengths_cell = sg_table.rows[1].cells[0]
@@ -701,11 +745,15 @@ def render_conclusion(doc, annex_data: dict):
 
     if conclusion.get("final_assessment"):
         add_heading_paragraph(doc, "Evaluación final", level=2)
-        add_body_paragraph(doc, conclusion.get("final_assessment"), color_rgb=BASE_TEXT_COLOR)
+        add_body_paragraph(
+            doc, conclusion.get("final_assessment"), color_rgb=BASE_TEXT_COLOR
+        )
 
     if conclusion.get("executive_message"):
         add_heading_paragraph(doc, "Mensaje para el responsable técnico", level=2)
-        add_body_paragraph(doc, conclusion.get("executive_message"), color_rgb=BASE_TEXT_COLOR)
+        add_body_paragraph(
+            doc, conclusion.get("executive_message"), color_rgb=BASE_TEXT_COLOR
+        )
 
     priority_areas = conclusion.get("priority_focus_areas", [])
     if priority_areas:
@@ -719,7 +767,9 @@ def render_conclusion(doc, annex_data: dict):
 
     if conclusion.get("closing_statement"):
         add_heading_paragraph(doc, "Próximos pasos", level=2)
-        add_body_paragraph(doc, conclusion.get("closing_statement"), color_rgb=BASE_TEXT_COLOR)
+        add_body_paragraph(
+            doc, conclusion.get("closing_statement"), color_rgb=BASE_TEXT_COLOR
+        )
 
 
 def render_blueprint(

--- a/src/assessment_engine/scripts/render_web_presentation.py
+++ b/src/assessment_engine/scripts/render_web_presentation.py
@@ -10,6 +10,10 @@ from typing import Any
 from assessment_engine.schemas.blueprint import BlueprintPayload
 from assessment_engine.schemas.global_report import GlobalReportPayload
 from assessment_engine.scripts.lib.global_maturity_policy import average_pillar_target
+from assessment_engine.scripts.lib.maturity_band import (
+    GLOBAL_MATURITY_BANDS,
+    resolve_maturity_band,
+)
 from assessment_engine.scripts.lib.runtime_paths import (
     resolve_blueprint_payload_candidates,
     resolve_client_dir,
@@ -51,6 +55,28 @@ def _safe_float(value: Any, default: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _try_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(str(value).split()[0].replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_tower_meta(tower_meta: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(tower_meta)
+    if normalized.get("band") not in (None, ""):
+        return normalized
+
+    score = _try_float(normalized.get("score"))
+    if score is None:
+        return normalized
+
+    normalized["band"] = resolve_maturity_band(score, GLOBAL_MATURITY_BANDS)["label"]
+    return normalized
 
 
 def _compute_global_score(global_payload: dict[str, Any]) -> str:
@@ -125,6 +151,10 @@ def _build_strategy(global_payload: dict[str, Any], client_id: str) -> dict[str,
     executive_summary = global_payload.get("executive_summary", {})
     target_vision = global_payload.get("target_vision", {})
     execution_roadmap = global_payload.get("execution_roadmap", {})
+    heatmap = [
+        _normalize_tower_meta(tower_meta)
+        for tower_meta in global_payload.get("heatmap", [])
+    ]
 
     return {
         "meta": {"client": client_id.upper(), "version": "v5.1 Strategic Ops"},
@@ -147,7 +177,7 @@ def _build_strategy(global_payload: dict[str, Any], client_id: str) -> dict[str,
             "proactive_proposals": execution_roadmap.get("proactive_proposals", [])
             or _default_proposals(),
         },
-        "heatmap": global_payload.get("heatmap", []),
+        "heatmap": heatmap,
         "towers": {},
     }
 
@@ -235,19 +265,20 @@ def _build_tower_nexus(
     tower_meta: dict[str, Any],
     blueprint_payload: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    score = _safe_float(tower_meta.get("score"), 2.5)
+    normalized_tower_meta = _normalize_tower_meta(tower_meta)
+    score = _safe_float(normalized_tower_meta.get("score"), 2.5)
     default_complexity = _derive_complexity(score)
 
     tower_nexus: dict[str, Any] = {
         "meta": {
-            **tower_meta,
-            "status_color": tower_meta.get("status_color", "38BDF8"),
+            **normalized_tower_meta,
+            "status_color": normalized_tower_meta.get("status_color", "38BDF8"),
         },
-        "executive_summary": tower_meta.get("executive_message", ""),
+        "executive_summary": normalized_tower_meta.get("executive_message", ""),
         "pillars": [],
         "decisions": [],
         "cost_of_inaction": "",
-        "target_maturity": str(tower_meta.get("target_maturity", "4.0")),
+        "target_maturity": str(normalized_tower_meta.get("target_maturity", "4.0")),
         "complexity": default_complexity,
         "structural_risks": [],
         "business_impact": "",

--- a/src/assessment_engine/scripts/run_evidence_analyst.py
+++ b/src/assessment_engine/scripts/run_evidence_analyst.py
@@ -2,10 +2,12 @@
 Módulo run_evidence_analyst.py.
 Contiene la lógica y utilidades principales para el pipeline de Assessment Engine.
 """
+
 import argparse
 import json
 from pathlib import Path
 
+from assessment_engine.scripts.lib.maturity_band import resolve_maturity_band
 from assessment_engine.scripts.lib.runtime_paths import ROOT
 
 
@@ -42,10 +44,9 @@ def first_kpi_evidence_refs(
 
 
 def band_for_score(score: float, tower_definition: dict) -> str:
-    for band in tower_definition.get("score_bands", []):
-        if band["min"] <= score <= band["max"]:
-            return band["label"]
-    return tower_definition["score_bands"][-1]["label"]
+    return resolve_maturity_band(score, tower_definition.get("score_bands", []))[
+        "label"
+    ]
 
 
 def capability_phrase(kpi_name: str) -> str:

--- a/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
+++ b/src/assessment_engine/scripts/run_executive_annex_synthesizer.py
@@ -2,6 +2,7 @@
 Módulo run_executive_annex_synthesizer.py.
 Implementa el flujo Top-Down: Toma el Blueprint y genera el resumen para el Anexo del CTO.
 """
+
 import asyncio
 import json
 import re
@@ -10,7 +11,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from google.adk.agents import Agent
 from vertexai.agent_engines import AdkApp
 
@@ -24,10 +25,17 @@ from assessment_engine.schemas.blueprint import BlueprintPayload
 from assessment_engine.schemas.common import VersionMetadata
 from assessment_engine.scripts.build_case_input import read_text
 from assessment_engine.scripts.lib.ai_client import run_agent
+from assessment_engine.scripts.lib.client_intelligence import (
+    load_client_intelligence_legacy_view,
+)
 from assessment_engine.scripts.lib.config_loader import (
     resolve_model_profile_for_role,
 )
 from assessment_engine.scripts.lib.contract_utils import robust_load_payload
+from assessment_engine.scripts.lib.maturity_band import (
+    ANNEX_MATURITY_BANDS,
+    resolve_maturity_band,
+)
 from assessment_engine.scripts.lib.runtime_paths import (
     resolve_annex_template_payload_path,
     resolve_blueprint_payload_path,
@@ -35,24 +43,15 @@ from assessment_engine.scripts.lib.runtime_paths import (
     resolve_client_dir,
     resolve_client_intelligence_path,
 )
-from assessment_engine.scripts.lib.client_intelligence import (
-    load_client_intelligence_legacy_view,
-)
 
 ROOT = Path(__file__).resolve().parents[3]
 PRIORITY_RANK = {"Alta": 0, "Media": 1, "Baja": 2}
 
+
 # Helper functions (side-effect free)
 def derive_maturity_band(score: float) -> str:
-    if score >= 4.5:
-        return "Optimizado"
-    if score >= 3.5:
-        return "Gestionado"
-    if score >= 2.5:
-        return "Definido"
-    if score >= 1.5:
-        return "Repetible"
-    return "Inicial"
+    return resolve_maturity_band(score, ANNEX_MATURITY_BANDS)["label"]
+
 
 def infer_priority_from_size(sizing: str) -> str:
     text = str(sizing or "").strip().lower()
@@ -63,6 +62,7 @@ def infer_priority_from_size(sizing: str) -> str:
     if text in {"l", "xl", "large"}:
         return "Baja"
     return "Media"
+
 
 def truncate_list(items, limit):
     return items[:limit] if isinstance(items, list) else items
@@ -197,7 +197,9 @@ def derive_gap_rows(blueprint: BlueprintPayload) -> tuple[list[str], list[GapRow
     target_capabilities: list[str] = []
     gap_rows: list[GapRowAnnex] = []
     for pillar in sorted(blueprint.pillars_analysis, key=lambda item: item.score):
-        primary_finding = pillar.health_check_asis[0] if pillar.health_check_asis else None
+        primary_finding = (
+            pillar.health_check_asis[0] if pillar.health_check_asis else None
+        )
         if pillar.target_architecture_tobe.vision:
             target_capabilities.append(
                 f"{pillar.pilar_name}: {take_complete_sentences(pillar.target_architecture_tobe.vision, max_sentences=2, max_chars=420)}"
@@ -385,11 +387,15 @@ def enrich_annex_payload(
         for pillar in blueprint.pillars_analysis
     ]
     if radar_chart_path.exists():
-        result_payload.pillar_score_profile.radar_chart = str(radar_chart_path.resolve())
+        result_payload.pillar_score_profile.radar_chart = str(
+            radar_chart_path.resolve()
+        )
 
     result_payload.executive_summary.global_score = f"{avg_score} / 5.0"
     result_payload.executive_summary.global_band = derive_maturity_band(avg_score)
-    if str(avg_target_score) not in str(result_payload.executive_summary.target_maturity):
+    if str(avg_target_score) not in str(
+        result_payload.executive_summary.target_maturity
+    ):
         result_payload.executive_summary.target_maturity = f"{avg_target_score:.1f}"
 
     result_payload.domain_introduction.technological_domain = (
@@ -418,8 +424,11 @@ def enrich_annex_payload(
     )
     return result_payload
 
+
 def load_yaml_config(filename: str) -> dict:
-    filepath = Path(__file__).resolve().parent.parent / "prompts" / "registry" / filename
+    filepath = (
+        Path(__file__).resolve().parent.parent / "prompts" / "registry" / filename
+    )
     with filepath.open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
@@ -431,8 +440,8 @@ def build_synthesis_prompt(
     context_summary: str,
     config: dict,
 ) -> str:
-    tower_name = (
-        blueprint_data.get("document_meta", {}).get("tower_name", "la torre evaluada")
+    tower_name = blueprint_data.get("document_meta", {}).get(
+        "tower_name", "la torre evaluada"
     )
     prompt = (
         f"Eres un {config['role']} con expertise en {config['expertise']}.\n"
@@ -459,6 +468,7 @@ def build_synthesis_prompt(
     prompt += "Devuelve exclusivamente el JSON final del anexo.\n"
     return prompt
 
+
 # --- Pure Business Logic Function ---
 async def generate_synthesis(
     blueprint: BlueprintPayload,
@@ -466,7 +476,7 @@ async def generate_synthesis(
     context_summary: str,
     config: dict,
     radar_chart_path: Path,
-    run_id: str
+    run_id: str,
 ) -> Optional[AnnexPayload]:
     """
     Toma los datos de entrada, ejecuta el agente IA y devuelve el payload del anexo enriquecido.
@@ -480,7 +490,7 @@ async def generate_synthesis(
         context_summary=context_summary,
         config=config,
     )
-    
+
     try:
         model_name = resolve_model_profile_for_role("section_writer")["model"]
     except Exception:
@@ -490,22 +500,23 @@ async def generate_synthesis(
         name="executive_synthesizer",
         model=model_name,
         instruction=f"Eres un {config['role']}. Tu misión es: {config['mission']}",
-        output_schema=AnnexPayload
+        output_schema=AnnexPayload,
     )
     app = AdkApp(agent=agent)
-    
+
     result = await run_agent(
         app,
         user_id=f"synthesizer_{blueprint.document_meta.tower_code}",
-        message=prompt, # El prompt se construiría aquí como antes
-        schema=AnnexPayload
+        message=prompt,  # El prompt se construiría aquí como antes
+        schema=AnnexPayload,
     )
-    
+
     if not result:
         return None
 
     result_payload = AnnexPayload.model_validate(result)
     return enrich_annex_payload(result_payload, blueprint, radar_chart_path, run_id)
+
 
 # --- I/O Orchestrator Function ---
 async def synthesize_annex(client_name: str, tower_id: str):
@@ -513,8 +524,10 @@ async def synthesize_annex(client_name: str, tower_id: str):
     Orquesta el proceso de síntesis del anexo ejecutivo. Maneja I/O.
     """
     run_id = f"run_{uuid.uuid4()}"
-    print(f"🧠 [Top-Down] Sintetizando Anexo Ejecutivo para {tower_id} (Run ID: {run_id})...")
-    
+    print(
+        f"🧠 [Top-Down] Sintetizando Anexo Ejecutivo para {tower_id} (Run ID: {run_id})..."
+    )
+
     client_dir = resolve_client_dir(client_name)
     tower_dir = client_dir / tower_id
     blueprint_path = resolve_blueprint_payload_path(client_name, tower_id)
@@ -522,7 +535,7 @@ async def synthesize_annex(client_name: str, tower_id: str):
     client_intelligence_path = resolve_client_intelligence_path(client_name)
     case_input_path = resolve_case_input_path(client_name, tower_id)
     radar_chart_path = tower_dir / "pillar_radar_chart.generated.png"
-    
+
     if not blueprint_path.exists():
         print(f"❌ Error: No se encontró el Blueprint en {blueprint_path}")
         return
@@ -538,13 +551,12 @@ async def synthesize_annex(client_name: str, tower_id: str):
     context_summary = ""
     if case_input_path.exists():
         case_input = json.loads(case_input_path.read_text(encoding="utf-8"))
-        context_file = (
-            case_input.get("_build_metadata", {}).get("context_file")
-            or case_input.get("context_file")
-        )
+        context_file = case_input.get("_build_metadata", {}).get(
+            "context_file"
+        ) or case_input.get("context_file")
         if context_file and Path(context_file).exists():
             context_summary = read_text(Path(context_file))
-    
+
     final_payload = await generate_synthesis(
         blueprint,
         client_intelligence,
@@ -553,15 +565,20 @@ async def synthesize_annex(client_name: str, tower_id: str):
         radar_chart_path,
         run_id,
     )
-    
+
     if final_payload:
-        output_path.write_text(final_payload.model_dump_json(indent=2, by_alias=True), encoding="utf-8")
+        output_path.write_text(
+            final_payload.model_dump_json(indent=2, by_alias=True), encoding="utf-8"
+        )
         print(f"✅ Anexo Ejecutivo sintetizado con éxito: {output_path}")
     else:
         print("❌ Error al generar el anexo.")
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print("Uso: python -m assessment_engine.scripts.run_executive_annex_synthesizer <client> <tower>")
+        print(
+            "Uso: python -m assessment_engine.scripts.run_executive_annex_synthesizer <client> <tower>"
+        )
         sys.exit(1)
     asyncio.run(synthesize_annex(sys.argv[1], sys.argv[2]))

--- a/src/assessment_engine/scripts/run_scoring.py
+++ b/src/assessment_engine/scripts/run_scoring.py
@@ -2,10 +2,12 @@
 Módulo run_scoring.py.
 Contiene la lógica y utilidades principales para el pipeline de Assessment Engine.
 """
+
 import argparse
 import json
 from pathlib import Path
 
+from assessment_engine.scripts.lib.maturity_band import resolve_maturity_band
 from assessment_engine.scripts.lib.runtime_paths import ROOT
 
 
@@ -22,11 +24,13 @@ def round_display(value: float) -> float:
 
 
 def resolve_band(score: float, tower_definition: dict) -> dict:
-    normalized_score = round(score, 4)
-    for band in tower_definition.get("score_bands", []):
-        if band["min"] <= normalized_score <= band["max"]:
-            return band
-    return tower_definition.get("score_bands", [])[-1]
+    return dict(
+        resolve_maturity_band(
+            score,
+            tower_definition.get("score_bands", []),
+            score_precision=4,
+        )
+    )
 
 
 def build_scoring(case_input: dict, tower_definition: dict) -> dict:

--- a/tests/test_maturity_band.py
+++ b/tests/test_maturity_band.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from assessment_engine.scripts.lib.maturity_band import (
+    ANNEX_MATURITY_BANDS,
+    GLOBAL_MATURITY_BANDS,
+    MaturityBandDefinition,
+    resolve_maturity_band,
+)
+
+
+def test_resolve_maturity_band_honors_precision_before_matching_ranges() -> None:
+    tower_bands: tuple[MaturityBandDefinition, ...] = (
+        {"min": 1.0, "max": 1.8, "label": "Level 1"},
+        {"min": 1.8, "max": 2.6, "label": "Level 2"},
+        {"min": 2.6, "max": 3.4, "label": "Level 3"},
+    )
+
+    assert (
+        resolve_maturity_band(
+            2.60005,
+            tower_bands,
+            score_precision=4,
+        )["label"]
+        == "Level 2"
+    )
+    assert (
+        resolve_maturity_band(
+            2.60015,
+            tower_bands,
+            score_precision=4,
+        )["label"]
+        == "Level 3"
+    )
+
+
+def test_resolve_maturity_band_uses_first_matching_range_and_last_fallback() -> None:
+    tower_bands: tuple[MaturityBandDefinition, ...] = (
+        {"min": 1.0, "max": 1.8, "label": "Level 1"},
+        {"min": 1.8, "max": 2.6, "label": "Level 2"},
+        {"min": 2.6, "max": 3.4, "label": "Level 3"},
+    )
+
+    assert resolve_maturity_band(1.8, tower_bands)["label"] == "Level 1"
+    assert resolve_maturity_band(0.5, tower_bands)["label"] == "Level 3"
+
+
+def test_resolve_maturity_band_supports_shared_annex_and_global_policies() -> None:
+    assert resolve_maturity_band(1.49, ANNEX_MATURITY_BANDS)["label"] == "Inicial"
+    assert resolve_maturity_band(3.5, ANNEX_MATURITY_BANDS)["label"] == "Gestionado"
+    assert resolve_maturity_band(3.49, GLOBAL_MATURITY_BANDS)["label"] == "Básica"
+    assert resolve_maturity_band(3.5, GLOBAL_MATURITY_BANDS)["label"] == "Optimizada"
+
+
+def test_resolve_maturity_band_requires_at_least_one_band() -> None:
+    with pytest.raises(ValueError, match="At least one maturity band is required"):
+        resolve_maturity_band(3.0, ())

--- a/tests/test_maturity_band_characterization.py
+++ b/tests/test_maturity_band_characterization.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import pytest
+from docx import Document
+
+from assessment_engine.schemas.blueprint import BlueprintPayload
+from assessment_engine.scripts.render_tower_blueprint import (
+    render_maturity_profile,
+    render_snapshot_page,
+)
+from assessment_engine.scripts.render_web_presentation import (
+    _build_strategy,
+    _build_tower_nexus,
+    _render_html,
+)
+from assessment_engine.scripts.run_scoring import build_scoring, resolve_band
+
+
+def _tower_definition() -> dict:
+    return {
+        "working_rules": {
+            "score_indicator": "mean",
+            "score_pillar": "mean",
+            "score_tower": "weighted_mean",
+        },
+        "pillars": [
+            {
+                "pillar_id": "T1.P1",
+                "pillar_name": "Pillar One",
+                "weight_pct": 100,
+                "kpis": [{"kpi_id": "T1.P1.K1"}],
+            }
+        ],
+        "score_bands": [
+            {"min": 1.0, "max": 1.8, "label": "Level 1"},
+            {"min": 1.8, "max": 2.6, "label": "Level 2"},
+            {"min": 2.6, "max": 3.4, "label": "Level 3"},
+            {"min": 3.4, "max": 4.2, "label": "Level 4"},
+            {"min": 4.2, "max": 5.0, "label": "Level 5"},
+        ],
+        "maturity_scale": [],
+    }
+
+
+def _blueprint_payload() -> BlueprintPayload:
+    return BlueprintPayload.model_validate(
+        {
+            "_generation_metadata": {
+                "artifact_type": "blueprint_payload",
+                "artifact_version": "1.0.0",
+            },
+            "document_meta": {
+                "client_name": "characterization-client",
+                "tower_name": "Test Tower 1",
+                "tower_code": "T1",
+                "financial_tier": "mid",
+                "transformation_horizon": "12m",
+            },
+            "executive_snapshot": {
+                "bottom_line": "BP Summary",
+                "decisions": ["Decision 1"],
+                "cost_of_inaction": "Cost",
+                "structural_risks": ["Risk"],
+                "business_impact": "Impact",
+                "operational_benefits": ["Benefit"],
+                "transformation_complexity": "Media",
+            },
+            "cross_capabilities_analysis": {
+                "common_deficiency_patterns": ["Pattern"],
+                "transformation_paradigm": "Paradigm",
+                "critical_technical_debt": "Debt",
+            },
+            "roadmap": [{"wave": "Wave 1", "projects": ["Project 1"]}],
+            "external_dependencies": [
+                {
+                    "project": "Project 1",
+                    "depends_on": "Dependency 1",
+                    "reason": "Because",
+                }
+            ],
+            "pillars_analysis": [
+                {
+                    "pilar_id": "P1",
+                    "pilar_name": "Pillar 1",
+                    "score": 3.5,
+                    "target_score": 4.0,
+                    "health_check_asis": [
+                        {
+                            "capability": "Capability 1",
+                            "finding": "Finding 1",
+                            "business_risk": "Risk 1",
+                        }
+                    ],
+                    "target_architecture_tobe": {
+                        "vision": "Vision 1",
+                        "design_principles": ["Principle 1"],
+                    },
+                    "projects_todo": [
+                        {
+                            "name": "Project 1",
+                            "business_case": "Business case 1",
+                            "tech_objective": "Objective 1",
+                            "deliverables": ["Deliverable 1"],
+                            "sizing": "M",
+                            "duration": "3 months",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("score", "expected_label"),
+    [
+        (1.0, "Level 1"),
+        (1.8, "Level 1"),
+        (1.8001, "Level 2"),
+        (2.6, "Level 2"),
+        (2.60004, "Level 2"),
+        (2.60005, "Level 2"),
+        (2.60015, "Level 3"),
+        (3.4, "Level 3"),
+        (4.2, "Level 4"),
+        (5.1, "Level 5"),
+        (0.5, "Level 5"),
+    ],
+)
+def test_scoring_band_mapping_characterizes_boundaries_rounding_and_fallback(
+    score: float,
+    expected_label: str,
+) -> None:
+    assert resolve_band(score, _tower_definition())["label"] == expected_label
+
+
+def test_scoring_build_uses_exact_internal_score_instead_of_display_rounding() -> None:
+    scoring = build_scoring(
+        case_input={
+            "case_id": "case-1",
+            "tower_id": "T1",
+            "tower_name": "Test Tower",
+            "answers": [{"kpi_id": "T1.P1.K1", "value": 2.64994}],
+        },
+        tower_definition=_tower_definition(),
+    )
+
+    assert scoring["tower_score_exact"] == pytest.approx(2.6499)
+    assert scoring["tower_score_display_1d"] == 2.6
+    assert scoring["maturity_band_from_exact"]["label"] == "Level 3"
+
+
+def test_blueprint_snapshot_uses_annex_global_band_without_recomputing() -> None:
+    doc = Document()
+
+    render_snapshot_page(
+        doc,
+        _blueprint_payload(),
+        client_intelligence={},
+        annex_data={
+            "executive_summary": {
+                "global_score": "2.6 / 5.0",
+                "global_band": "Band From Annex",
+                "target_maturity": "4.0",
+            }
+        },
+    )
+
+    assert doc.tables[0].rows[1].cells[1].text == "Band From Annex"
+
+
+def test_blueprint_snapshot_derives_annex_global_band_from_shared_policy() -> None:
+    doc = Document()
+
+    render_snapshot_page(
+        doc,
+        _blueprint_payload(),
+        client_intelligence={},
+        annex_data={
+            "executive_summary": {
+                "global_score": "3.5 / 5.0",
+                "target_maturity": "4.0",
+            }
+        },
+    )
+
+    assert doc.tables[0].rows[1].cells[1].text == "Gestionado"
+
+
+def test_blueprint_maturity_profile_uses_annex_pillar_band_without_recomputing() -> (
+    None
+):
+    doc = Document()
+
+    render_maturity_profile(
+        doc,
+        {
+            "pillar_score_profile": {
+                "profile_intro": "",
+                "scoring_method_note": "",
+                "pillars": [
+                    {
+                        "pillar_label": "Pillar 1",
+                        "score_display": "2.6",
+                        "maturity_band": "Band From Annex Pillar",
+                        "executive_reading": "Reading",
+                    }
+                ],
+            },
+            "sections": {
+                "asis": {
+                    "narrative": "",
+                    "strengths": [],
+                    "gaps": [],
+                    "operational_impacts": [],
+                }
+            },
+        },
+    )
+
+    assert doc.tables[0].rows[1].cells[2].text == "Band From Annex Pillar"
+
+
+def test_blueprint_maturity_profile_derives_pillar_band_from_shared_policy() -> None:
+    doc = Document()
+
+    render_maturity_profile(
+        doc,
+        {
+            "pillar_score_profile": {
+                "profile_intro": "",
+                "scoring_method_note": "",
+                "pillars": [
+                    {
+                        "pillar_label": "Pillar 1",
+                        "score_display": "2.6 / 5.0",
+                        "executive_reading": "Reading",
+                    }
+                ],
+            },
+            "sections": {
+                "asis": {
+                    "narrative": "",
+                    "strengths": [],
+                    "gaps": [],
+                    "operational_impacts": [],
+                }
+            },
+        },
+    )
+
+    assert doc.tables[0].rows[1].cells[2].text == "Definido"
+
+
+def test_web_dashboard_derives_band_from_score_when_missing() -> None:
+    tower_meta = {
+        "id": "T1",
+        "name": "Test Tower 1",
+        "score": "3.5",
+        "status_color": "93C47D",
+        "executive_message": "Bottom line",
+        "target_maturity": "4.0",
+    }
+    strategy = _build_strategy(
+        {
+            "executive_summary": {
+                "headline": "",
+                "narrative": "",
+                "key_business_impacts": [],
+            },
+            "target_vision": {},
+            "execution_roadmap": {},
+            "heatmap": [tower_meta],
+            "meta": {},
+        },
+        "client",
+    )
+    tower_nexus = _build_tower_nexus(tower_meta, blueprint_payload=None)
+
+    assert strategy["heatmap"][0]["band"] == "Optimizada"
+    assert tower_nexus["meta"]["band"] == "Optimizada"
+
+
+def test_web_dashboard_keeps_band_as_passthrough_until_template_uppercases_it() -> None:
+    tower_meta = {
+        "id": "T1",
+        "name": "Test Tower 1",
+        "score": "3.0",
+        "band": "Band MiXa",
+        "status_color": "FFD966",
+        "executive_message": "Bottom line",
+        "target_maturity": "4.0",
+    }
+    tower_nexus = _build_tower_nexus(tower_meta, blueprint_payload=None)
+
+    html = _render_html(
+        "client",
+        {
+            "meta": {"client": "CLIENT", "version": "v5.1 Strategic Ops"},
+            "strategy": {
+                "headline": "",
+                "narrative": "",
+                "global_score": "3.0",
+                "burning_platform": [],
+                "principles": [],
+                "architecture_principles": [],
+                "operating_model": [],
+                "gtm_strategy": {},
+                "stakeholders": [],
+                "business_impacts": [],
+                "estimated_tam": "TBD",
+            },
+            "roadmap": {
+                "programs": [],
+                "horizons": {},
+                "proactive_proposals": [],
+            },
+            "heatmap": [tower_meta],
+            "towers": {"T1": tower_nexus},
+        },
+    )
+
+    assert tower_nexus["meta"]["band"] == "Band MiXa"
+    assert '"band": "Band MiXa"' in html
+    assert "(t.meta.band || '---').toUpperCase()" in html


### PR DESCRIPTION
## Summary
- La lógica para traducir un score numérico a una banda de madurez cualitativa está duplicada y hardcodeada en múltiples artefactos (scoring, annex, blueprint, global, web), lo que genera inconsistencia, sobrecarga de mantenimiento y riesgo de divergencia.
- Establecer una única fuente de verdad para el mapeo que sea consumida por todos los artefactos. Esto reducirá la deuda técnica, garantizará la coherencia en todo el sistema y simplificará futuras modificaciones de las bandas de madurez.

## Change spec
- Problem: La lógica para traducir un score numérico a una banda de madurez cualitativa está duplicada y hardcodeada en múltiples artefactos (scoring, annex, blueprint, global, web), lo que genera inconsistencia, sobrecarga de mantenimiento y riesgo de divergencia.
- In scope: Crear un nuevo módulo/utilidad compartida que contenga la lógica de traducción de score a banda., Refactorizar los artefactos 'scoring', 'annex', 'blueprint', 'global' y 'web' para que utilicen la nueva utilidad centralizada., Eliminar las implementaciones locales y duplicadas de la lógica de mapeo., Asegurar que el comportamiento final sea idéntico al actual, preservando los contratos de las APIs y los datos generados.
- Out of scope: Modificar los umbrales de score o los nombres de las bandas de madurez., Cambiar los contratos públicos (API, formatos de datos) de los artefactos afectados., Introducir nuevas bandas de madurez o eliminar existentes., Realizar cualquier otra refactorización no relacionada con el mapeo de score.
- Source of truth: El código fuente existente en los artefactos 'scoring', 'annex', 'blueprint', 'global' y 'web' que actualmente implementan la lógica de mapeo., Los tests de smoke y de integración existentes que validan el comportamiento actual.
- Invariants to preserve: Los contratos de las APIs de todos los servicios afectados deben permanecer sin cambios., Para un mismo score de entrada, la banda de madurez de salida debe ser idéntica a la producida por la lógica anterior., Todos los tests de smoke deben pasar sin modificaciones., El rendimiento no debe verse degradado.
- Validation plan: Crear tests de caracterización que capturen el output actual de la lógica de mapeo para un rango amplio de scores., Verificar que la nueva utilidad centralizada pasa todos los tests de caracterización., Ejecutar el conjunto completo de tests (unitarios, integración, E2E) para todos los artefactos afectados y asegurar que todos pasan., Realizar una validación manual en el frontend (web) para confirmar que las bandas se muestran correctamente para diferentes scores de prueba., Ejecutar el smoke test completo en un entorno de staging antes del merge.

## Tasks
- [spec-and-characterize-mapping] Definir y testear el mapeo unificado
- [implement-central-utility] Implementar la utilidad de mapeo centralizada
- [refactor-consumers] Refactorizar consumidores para usar la utilidad central

## Governance checks
- [x] Planned from a minimal explicit spec
- [x] Scoped as bounded iterative tasks
- [x] Validation and canonical documentation considered
