### PR TITLE
feat: annotate bot thread resolutions

### DIFF
--- a/.github/scripts/orchestrator-github-executor.sh
+++ b/.github/scripts/orchestrator-github-executor.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <repo_root> <task_prompt_file> [attempt]" >&2
+  exit 2
+fi
+
+repo_root=$1
+task_prompt_file=$2
+attempt=${3:-1}
+
+cd "$repo_root"
+
+copilot_auth_token=${COPILOT_REQUESTS_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}
+if [ -z "$copilot_auth_token" ]; then
+  echo "COPILOT_REQUESTS_TOKEN or GITHUB_TOKEN is required for the GitHub Actions executor." >&2
+  exit 2
+fi
+
+export GH_TOKEN="$copilot_auth_token"
+export GITHUB_TOKEN="$copilot_auth_token"
+
+exec copilot \
+  --model gpt-5.4 \
+  --allow-all \
+  --no-ask-user \
+  --silent \
+  --log-level error \
+  --name "orchestrator-pr-reconcile-${attempt}" \
+  -p "$(cat "$task_prompt_file")"

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -144,12 +144,19 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
           pip install pytest pytest-asyncio pytest-mock
+          npm install -g @github/copilot
 
       - name: Resume orchestrator reconciliation
         env:
@@ -157,6 +164,7 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           EXECUTOR_CMD_SECRET: ${{ secrets.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
           EXECUTOR_CMD_VAR: ${{ vars.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
+          COPILOT_REQUESTS_TOKEN: ${{ secrets.COPILOT_REQUESTS_TOKEN }}
           PYTHONDONTWRITEBYTECODE: "1"
           PYTHONPATH: src
         run: |
@@ -168,8 +176,7 @@ jobs:
           fi
 
           if [ -z "$executor_command" ]; then
-            echo "::warning::Skipping automatic reconciliation because ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD is not configured."
-            exit 0
+            executor_command="./.github/scripts/orchestrator-github-executor.sh {repo_root} {task_prompt_file} {attempt}"
           fi
 
           export ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD="$executor_command"

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -1,0 +1,168 @@
+name: Orchestrator PR Reconciliation
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to reconcile
+        required: true
+        type: string
+  workflow_run:
+    workflows:
+      - Assessment Engine CI
+      - Documentation Governance
+      - Incremental Quality Gate
+      - Incremental Type Check
+    types:
+      - completed
+  issue_comment:
+    types:
+      - created
+  pull_request_review:
+    types:
+      - submitted
+  pull_request_review_comment:
+    types:
+      - created
+
+jobs:
+  resolve-context:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      actions: read
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      branch: ${{ steps.resolve.outputs.branch }}
+    steps:
+      - name: Resolve PR context
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+        run: |
+          set -euo pipefail
+
+          pr_number=""
+          should_run=false
+          branch=""
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              pr_number="$INPUT_PR_NUMBER"
+              ;;
+            workflow_run)
+              if [ "$(jq -r '.workflow_run.event' "$GITHUB_EVENT_PATH")" = "pull_request" ]; then
+                pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+              fi
+              ;;
+            issue_comment)
+              if jq -e '.issue.pull_request != null' "$GITHUB_EVENT_PATH" >/dev/null && [ "$ACTOR" != "github-actions[bot]" ]; then
+                pr_number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
+              fi
+              ;;
+            pull_request_review|pull_request_review_comment)
+              if [ "$ACTOR" != "github-actions[bot]" ]; then
+                pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
+              fi
+              ;;
+          esac
+
+          if [ -z "$pr_number" ]; then
+            {
+              echo "should_run=false"
+              echo "pr_number="
+              echo "branch="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_json="$(gh api "repos/$REPOSITORY/pulls/$pr_number")"
+          state="$(jq -r '.state' <<<"$pr_json")"
+          draft="$(jq -r '.draft' <<<"$pr_json")"
+          same_repo="$(jq -r --arg repo "$REPOSITORY" '.head.repo.full_name == $repo' <<<"$pr_json")"
+          body="$(jq -r '.body // ""' <<<"$pr_json")"
+          branch="$(jq -r '.head.ref' <<<"$pr_json")"
+          label_match="$(jq -r '[.labels[].name == "orchestrator-managed"] | any' <<<"$pr_json")"
+          marker_match=false
+          if grep -q '<!-- orchestrator-managed -->' <<<"$body"; then
+            marker_match=true
+          fi
+
+          if [ "$state" = "open" ] \
+            && [ "$draft" = "false" ] \
+            && [ "$same_repo" = "true" ] \
+            && { [ "$label_match" = "true" ] || [ "$marker_match" = "true" ]; }
+          then
+            should_run=true
+          fi
+
+          {
+            echo "should_run=$should_run"
+            echo "pr_number=$pr_number"
+            echo "branch=$branch"
+          } >> "$GITHUB_OUTPUT"
+
+  reconcile:
+    needs: resolve-context
+    if: needs.resolve-context.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    concurrency:
+      group: orchestrator-pr-reconcile-${{ needs.resolve-context.outputs.pr_number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-context.outputs.branch }}
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest pytest-asyncio pytest-mock
+
+      - name: Resume orchestrator reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          EXECUTOR_CMD_SECRET: ${{ secrets.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
+          EXECUTOR_CMD_VAR: ${{ vars.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
+          PYTHONDONTWRITEBYTECODE: "1"
+          PYTHONPATH: src
+        run: |
+          set -euo pipefail
+
+          executor_command="$EXECUTOR_CMD_SECRET"
+          if [ -z "$executor_command" ]; then
+            executor_command="$EXECUTOR_CMD_VAR"
+          fi
+
+          if [ -z "$executor_command" ]; then
+            echo "::warning::Skipping automatic reconciliation because ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD is not configured."
+            exit 0
+          fi
+
+          export ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD="$executor_command"
+          python src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py \
+            resume-pr \
+            --pr-number "$PR_NUMBER"

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -18,6 +18,13 @@ on:
   issue_comment:
     types:
       - created
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
   pull_request_review:
     types:
       - submitted
@@ -66,6 +73,9 @@ jobs:
               if jq -e '.issue.pull_request != null' "$GITHUB_EVENT_PATH" >/dev/null && [ "$ACTOR" != "github-actions[bot]" ]; then
                 pr_number="$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")"
               fi
+              ;;
+            pull_request)
+              pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
               ;;
             pull_request_review|pull_request_review_comment)
               if [ "$ACTOR" != "github-actions[bot]" ]; then

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -148,7 +148,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 50
     concurrency:
       group: orchestrator-pr-reconcile-${{ needs.resolve-context.outputs.pr_number }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Si un documento narrativo contradice al código o a los contratos, **manda el re
 | `operations/engineering-quality-gates.md` | Política canónica de calidad de implementación |
 | `operations/product-owner-orchestrator.md` | Orquestador local desde petición de negocio hasta PR |
 | `../.github/workflows/orchestrator-pr-reconcile.yml` | Watcher automático que reanuda PRs gestionadas del orquestador |
+| `../.github/scripts/orchestrator-github-executor.sh` | Wrapper de executor para usar Copilot CLI dentro de GitHub Actions |
 | `contracts/` | Contratos, matrices y plantillas de diseño |
 | `reference/generated/` | Referencia derivada o heredada no canónica |
 | `../GEMINI.md` | Adaptador para Gemini y memoria operativa en transición |
@@ -105,6 +106,7 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - ya existe una guía canónica para exigir spec mínima y alcance explícito en cambios asistidos por agentes;
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
 - ya existe un watcher de GitHub que puede reanudar PRs gestionadas del orquestador cuando fallan checks o aparece feedback nuevo;
+- ya existe un executor del repo compatible con GitHub Actions para que el watcher no dependa de rutas locales;
 - el baseline smoke de `smoke_ivirma` ya está cerrado para T5, global, comercial y web;
 - la suite completa de `pytest` pasa.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Si un documento narrativo contradice al código o a los contratos, **manda el re
 | `operations/agentic-development-workflow.md` | Flujo canónico para programar con agentes |
 | `operations/engineering-quality-gates.md` | Política canónica de calidad de implementación |
 | `operations/product-owner-orchestrator.md` | Orquestador local desde petición de negocio hasta PR |
+| `../.github/workflows/orchestrator-pr-reconcile.yml` | Watcher automático que reanuda PRs gestionadas del orquestador |
 | `contracts/` | Contratos, matrices y plantillas de diseño |
 | `reference/generated/` | Referencia derivada o heredada no canónica |
 | `../GEMINI.md` | Adaptador para Gemini y memoria operativa en transición |
@@ -103,6 +104,7 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - la puerta incremental de tipado ya puede bloquear deuda nueva en la superficie viva;
 - ya existe una guía canónica para exigir spec mínima y alcance explícito en cambios asistidos por agentes;
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
+- ya existe un watcher de GitHub que puede reanudar PRs gestionadas del orquestador cuando fallan checks o aparece feedback nuevo;
 - el baseline smoke de `smoke_ivirma` ya está cerrado para T5, global, comercial y web;
 - la suite completa de `pytest` pasa.
 

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -220,9 +220,25 @@ entries:
     source_of_truth:
       - docs/operations/product-owner-orchestrator.md
       - docs/operations/engineering-quality-gates.md
+      - .github/scripts/orchestrator-github-executor.sh
       - src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
     last_verified_against: 2026-05-01
     notes: Workflow que reanuda automáticamente PRs gestionadas por el orquestador cuando llegan checks, comentarios o ejecuciones manuales.
+
+  - path: .github/scripts/orchestrator-github-executor.sh
+    kind: document
+    title: GitHub Actions executor wrapper for the product owner orchestrator
+    doc_type: operational
+    status: Verified
+    owner: docs-governance
+    applies_to:
+      - humans
+      - ai-agents
+    source_of_truth:
+      - docs/operations/product-owner-orchestrator.md
+      - .github/workflows/orchestrator-pr-reconcile.yml
+    last_verified_against: 2026-05-01
+    notes: Wrapper del repo que autentica Copilot CLI en GitHub Actions y ejecuta el prompt de reconciliación contra la rama activa.
 
   - path: docs/SYSTEM_ARCHITECTURE.md
     kind: document

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -208,6 +208,22 @@ entries:
     last_verified_against: 2026-05-01
     notes: Workflow que ejecuta el gate incremental de tipado sobre la superficie viva del proyecto.
 
+  - path: .github/workflows/orchestrator-pr-reconcile.yml
+    kind: document
+    title: Orchestrator PR reconciliation watcher
+    doc_type: operational
+    status: Verified
+    owner: docs-governance
+    applies_to:
+      - humans
+      - ai-agents
+    source_of_truth:
+      - docs/operations/product-owner-orchestrator.md
+      - docs/operations/engineering-quality-gates.md
+      - src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+    last_verified_against: 2026-05-01
+    notes: Workflow que reanuda automáticamente PRs gestionadas por el orquestador cuando llegan checks, comentarios o ejecuciones manuales.
+
   - path: docs/SYSTEM_ARCHITECTURE.md
     kind: document
     title: System architecture

--- a/docs/operations/engineering-quality-gates.md
+++ b/docs/operations/engineering-quality-gates.md
@@ -97,6 +97,7 @@ La automatización no sustituye la revisión de PR:
 - el checklist de `.github/pull_request_template.md` obliga a revisar impacto documental y de calidad;
 - `AGENTS.md` y `.github/copilot-instructions.md` remiten a esta política antes de programar con agentes;
 - la gobernanza documental sigue exigiendo actualizar la documentación canónica cuando cambian reglas, workflows o validadores.
+- el watcher `.github/workflows/orchestrator-pr-reconcile.yml`, cuando está habilitado para una PR gestionada, no sustituye estos gates: simplemente vuelve a invocar `resume-pr` para reejecutarlos y reaccionar al feedback de GitHub.
 
 ## Ejecución local recomendada
 

--- a/docs/operations/engineering-quality-gates.md
+++ b/docs/operations/engineering-quality-gates.md
@@ -98,6 +98,7 @@ La automatización no sustituye la revisión de PR:
 - `AGENTS.md` y `.github/copilot-instructions.md` remiten a esta política antes de programar con agentes;
 - la gobernanza documental sigue exigiendo actualizar la documentación canónica cuando cambian reglas, workflows o validadores.
 - el watcher `.github/workflows/orchestrator-pr-reconcile.yml`, cuando está habilitado para una PR gestionada, no sustituye estos gates: simplemente vuelve a invocar `resume-pr` para reejecutarlos y reaccionar al feedback de GitHub.
+- la configuración operativa estable del watcher incluye un executor del repo para GitHub Actions y un secret `COPILOT_REQUESTS_TOKEN`; sin esa base, el watcher puede existir pero no se considera plenamente preparado para autoreparación fiable.
 
 ## Ejecución local recomendada
 

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -122,7 +122,7 @@ La fase post-PR **no sustituye** los controles del repo ni los rebaja. Su papel 
 7. reconsultar la PR;
 8. mergear solo cuando GitHub deja de reportar checks pendientes/fallidos y no quedan conversaciones abiertas.
 
-Por defecto puede resolver automáticamente **threads abiertos creados por bots** una vez que la rama ya no tiene checks rojos ni pendientes. No auto-resuelve feedback humano implícitamente fuera de las reglas normales de GitHub: si la PR sigue bloqueada por requisitos externos de review o protección de rama, el merge no se fuerza.
+Por defecto puede resolver automáticamente **threads abiertos creados por bots** una vez que la rama ya no tiene checks rojos ni pendientes. Antes de cerrarlos deja una nota visible en el propio hilo explicando que el estado actual de la PR ya fue revalidado y por qué ese thread se considera cerrable. No auto-resuelve feedback humano implícitamente fuera de las reglas normales de GitHub: si la PR sigue bloqueada por requisitos externos de review o protección de rama, el merge no se fuerza.
 
 La sincronización con la base ocurre dentro del mismo circuito controlado: el orquestador trae `origin/<base_branch>` a la rama activa, vuelve a ejecutar las validaciones locales y solo hace push si la rama sigue pasando los gates. Si esa sincronización introduce un fallo, ese fallo entra como feedback de la siguiente ronda de reparación; no se salta.
 

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -109,6 +109,8 @@ Si todas las tareas pasan:
 4. si detecta fallos o feedback abierto, entra en un ciclo de reconciliación;
 5. solo mergea cuando la PR queda verde y sin conversaciones bloqueantes.
 
+Las PR creadas por este flujo incluyen un marcador oculto `<!-- orchestrator-managed -->`. Ese marcador permite que la automatización de GitHub identifique qué PRs puede reanudar sin ambigüedad.
+
 ### 5. Reconciliación post-PR
 
 La fase post-PR **no sustituye** los controles del repo ni los rebaja. Su papel es:
@@ -126,6 +128,22 @@ Por defecto puede resolver automáticamente **threads abiertos creados por bots*
 
 La sincronización con la base ocurre dentro del mismo circuito controlado: el orquestador trae `origin/<base_branch>` a la rama activa, vuelve a ejecutar las validaciones locales y solo hace push si la rama sigue pasando los gates. Si esa sincronización introduce un fallo, ese fallo entra como feedback de la siguiente ronda de reparación; no se salta.
 
+### 6. Watcher automático en GitHub
+
+El repo puede ejecutar `.github/workflows/orchestrator-pr-reconcile.yml` para relanzar `resume-pr` cuando una PR gestionada:
+
+1. recibe feedback de review o comentarios;
+2. termina un workflow relevante de CI;
+3. o se relanza manualmente con `workflow_dispatch`.
+
+Reglas de seguridad del watcher:
+
+- solo actúa sobre PRs **abiertas**, **no draft**, del **mismo repositorio**;
+- exige que la PR tenga el marcador oculto del orquestador o la label `orchestrator-managed`;
+- serializa la ejecución por número de PR para no correr dos reconciliaciones en paralelo;
+- reutiliza `resume-pr`, así que sigue pasando por tests, quality, typing, docs-governance, sync con `main` y reglas de review;
+- si falta `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` como secret o variable del repo, el watcher se salta sin forzar cambios.
+
 ## Política configurable
 
 `engine_config/policies/orchestrator_policy.json` controla:
@@ -136,6 +154,7 @@ La sincronización con la base ocurre dentro del mismo circuito controlado: el o
 - rama base;
 - modo de auto-merge;
 - reconciliación post-PR (polling, rondas máximas, sync con base y resolución automática de threads de bot);
+- watcher automático de reanudación para PRs gestionadas;
 - validaciones estándar.
 
 ## Limitaciones deliberadas del MVP

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -142,7 +142,9 @@ Reglas de seguridad del watcher:
 - exige que la PR tenga el marcador oculto del orquestador o la label `orchestrator-managed`;
 - serializa la ejecución por número de PR para no correr dos reconciliaciones en paralelo;
 - reutiliza `resume-pr`, así que sigue pasando por tests, quality, typing, docs-governance, sync con `main` y reglas de review;
-- si falta `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` como secret o variable del repo, el watcher se salta sin forzar cambios.
+- usa por defecto `./.github/scripts/orchestrator-github-executor.sh {repo_root} {task_prompt_file} {attempt}` como executor compatible con GitHub Actions;
+- la regla operativa recomendada es mantener `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` configurado en GitHub Actions apuntando a ese wrapper del repo, para no depender de rutas locales o wrappers efímeros;
+- para que el executor pueda autenticarse de forma estable en GitHub Actions, el repo debe tener `COPILOT_REQUESTS_TOKEN` como secret con permiso `Copilot Requests`; si no existe, el wrapper intentará usar `GITHUB_TOKEN`, pero la configuración soportada para operación estable es el secret dedicado.
 
 ## Política configurable
 

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -44,6 +44,7 @@ query($owner:String!, $repo:String!, $number:Int!) {
           line
           comments(first:20) {
             nodes {
+              databaseId
               author {
                 __typename
                 login
@@ -399,6 +400,7 @@ def normalize_review_threads(threads: list[dict[str, Any]]) -> list[dict[str, An
                 "is_outdated": bool(thread.get("isOutdated")),
                 "comments": [
                     {
+                        "database_id": comment.get("databaseId"),
                         "author": author["login"],
                         "author_type": author["type"],
                         "body": comment.get("body", ""),
@@ -484,9 +486,23 @@ def is_pull_request_ready_for_merge(pr_state: dict[str, Any]) -> bool:
 
 def auto_resolve_bot_threads(pr_state: dict[str, Any]) -> int:
     resolved = 0
+    owner, repo = repository_coordinates()
     for thread in pr_state["unresolved_threads"]:
         if not thread["all_comments_bot"]:
             continue
+        last_comment = thread["comments"][-1] if thread["comments"] else None
+        comment_id = last_comment.get("database_id") if last_comment else None
+        if comment_id is not None:
+            resolution_note = build_bot_thread_resolution_note(thread)
+            run_git_command(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/pulls/{pr_state['number']}/comments/{comment_id}/replies",
+                    "-f",
+                    f"body={resolution_note}",
+                ]
+            )
         run_git_command(
             [
                 "gh",
@@ -500,6 +516,16 @@ def auto_resolve_bot_threads(pr_state: dict[str, Any]) -> int:
         )
         resolved += 1
     return resolved
+
+
+def build_bot_thread_resolution_note(thread: dict[str, Any]) -> str:
+    reason = "the repository checks are green"
+    if thread.get("is_outdated"):
+        reason += " and the commented lines are now outdated"
+    return (
+        "Automated reconciliation note: this bot-only thread is being resolved because "
+        f"{reason}. The current PR state has been revalidated before closure."
+    )
 
 
 def build_pr_feedback(pr_state: dict[str, Any]) -> dict[str, Any]:

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -493,9 +493,7 @@ def auto_resolve_bot_threads(pr_state: dict[str, Any]) -> int:
         if not thread["all_comments_bot"]:
             continue
         top_level_comment = thread["comments"][0] if thread["comments"] else None
-        comment_id = (
-            top_level_comment.get("database_id") if top_level_comment else None
-        )
+        comment_id = top_level_comment.get("database_id") if top_level_comment else None
         if comment_id is not None:
             resolution_note = build_bot_thread_resolution_note(thread)
             run_git_command(

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -31,6 +31,8 @@ from assessment_engine.scripts.lib.product_owner_models import ProductOwnerPlan
 from assessment_engine.scripts.lib.runtime_paths import ROOT
 from assessment_engine.scripts.lib.text_utils import slugify
 
+ORCHESTRATOR_MANAGED_MARKER = "<!-- orchestrator-managed -->"
+
 REVIEW_THREADS_QUERY = """
 query($owner:String!, $repo:String!, $number:Int!) {
   repository(owner:$owner, name:$repo) {
@@ -810,6 +812,8 @@ def reconcile_pull_request(
 
 def create_pr_body(plan: dict[str, Any]) -> str:
     sections = [
+        ORCHESTRATOR_MANAGED_MARKER,
+        "",
         "## Summary",
         f"- {plan['problem']}",
         f"- {plan['value_expected']}",

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -474,6 +474,50 @@ def inspect_pull_request(branch_name: str) -> dict[str, Any]:
     }
 
 
+def is_current_reconciliation_check(check: dict[str, Any]) -> bool:
+    run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+    details_url = str(check.get("details_url") or "")
+    if run_id and f"/actions/runs/{run_id}" in details_url:
+        return True
+
+    workflow_name = os.environ.get("GITHUB_WORKFLOW", "").strip()
+    if not workflow_name or check.get("workflow_name") != workflow_name:
+        return False
+
+    if check.get("status") == "COMPLETED":
+        return False
+
+    job_name = os.environ.get("GITHUB_JOB", "").strip()
+    return not job_name or check.get("name") == job_name
+
+
+def ignore_current_reconciliation_check(pr_state: dict[str, Any]) -> dict[str, Any]:
+    checks = pr_state.get("checks", [])
+    if not checks:
+        return pr_state
+
+    if not any(is_current_reconciliation_check(check) for check in checks):
+        return pr_state
+
+    filtered_checks = [
+        check for check in checks if not is_current_reconciliation_check(check)
+    ]
+    return {
+        **pr_state,
+        "checks": filtered_checks,
+        "failed_checks": [
+            check
+            for check in pr_state["failed_checks"]
+            if not is_current_reconciliation_check(check)
+        ],
+        "pending_checks": [
+            check
+            for check in pr_state["pending_checks"]
+            if not is_current_reconciliation_check(check)
+        ],
+    }
+
+
 def is_pull_request_ready_for_merge(pr_state: dict[str, Any]) -> bool:
     return (
         not pr_state["is_draft"]
@@ -734,7 +778,9 @@ def reconcile_pull_request(
     repair_rounds = 0
 
     for poll_index in range(1, max_polls + 1):
-        pr_state = inspect_pull_request(plan["branch_name"])
+        pr_state = ignore_current_reconciliation_check(
+            inspect_pull_request(plan["branch_name"])
+        )
         (request_dir / f"pr_state_{poll_index}.json").write_text(
             json.dumps(pr_state, ensure_ascii=False, indent=2),
             encoding="utf-8",

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -492,8 +492,10 @@ def auto_resolve_bot_threads(pr_state: dict[str, Any]) -> int:
     for thread in pr_state["unresolved_threads"]:
         if not thread["all_comments_bot"]:
             continue
-        last_comment = thread["comments"][-1] if thread["comments"] else None
-        comment_id = last_comment.get("database_id") if last_comment else None
+        top_level_comment = thread["comments"][0] if thread["comments"] else None
+        comment_id = (
+            top_level_comment.get("database_id") if top_level_comment else None
+        )
         if comment_id is not None:
             resolution_note = build_bot_thread_resolution_note(thread)
             run_git_command(

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -121,6 +121,7 @@ def test_inspect_pull_request_combines_checks_and_threads(monkeypatch) -> None:
                 "comments": {
                     "nodes": [
                         {
+                            "databaseId": 321,
                             "author": {
                                 "__typename": "Bot",
                                 "login": "chatgpt-codex-connector",
@@ -139,6 +140,7 @@ def test_inspect_pull_request_combines_checks_and_threads(monkeypatch) -> None:
     assert pr_state["number"] == 7
     assert pr_state["failed_checks"][0]["name"] == "quality"
     assert pr_state["unresolved_threads"][0]["all_comments_bot"] is True
+    assert pr_state["unresolved_threads"][0]["comments"][0]["database_id"] == 321
 
 
 def test_reconcile_pull_request_repairs_then_merges(
@@ -367,6 +369,53 @@ def test_reconcile_pull_request_auto_resolves_bot_threads(
     )
 
     assert call_order == ["resolve", "merge:11:squash"]
+
+
+def test_auto_resolve_bot_threads_replies_before_resolving(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        orchestrator,
+        "repository_coordinates",
+        lambda: ("josejavish1", "assessment_engine"),
+    )
+
+    def fake_run_git_command(args: list[str]):
+        calls.append(args)
+        return None
+
+    monkeypatch.setattr(orchestrator, "run_git_command", fake_run_git_command)
+
+    resolved = orchestrator.auto_resolve_bot_threads(
+        {
+            "number": 6,
+            "unresolved_threads": [
+                {
+                    "id": "thread-1",
+                    "is_outdated": True,
+                    "all_comments_bot": True,
+                    "comments": [
+                        {
+                            "database_id": 987,
+                            "author": "chatgpt-codex-connector",
+                            "author_type": "Bot",
+                            "body": "old comment",
+                            "state": "SUBMITTED",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert resolved == 1
+    assert calls[0][:4] == [
+        "gh",
+        "api",
+        "repos/josejavish1/assessment_engine/pulls/6/comments/987/replies",
+        "-f",
+    ]
+    assert "Automated reconciliation note:" in calls[0][4]
+    assert calls[1][:4] == ["gh", "api", "graphql", "-f"]
 
 
 def test_reconcile_pull_request_waits_for_pending_checks_before_repair(

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -151,6 +151,22 @@ def test_ignore_current_reconciliation_check_filters_active_workflow(
     monkeypatch.setenv("GITHUB_WORKFLOW", "Orchestrator PR Reconciliation")
     monkeypatch.setenv("GITHUB_JOB", "reconcile")
 
+    checks = [
+        {
+            "name": "reconcile",
+            "workflow_name": "Orchestrator PR Reconciliation",
+            "status": "IN_PROGRESS",
+            "conclusion": "",
+            "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
+        },
+        {
+            "name": "typing",
+            "workflow_name": "Incremental Type Check",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "details_url": "https://example.test/check",
+        },
+    ]
     pr_state = {
         "number": 7,
         "url": "https://example.test/pr/7",
@@ -158,22 +174,7 @@ def test_ignore_current_reconciliation_check_filters_active_workflow(
         "mergeable": "MERGEABLE",
         "merge_state_status": "BLOCKED",
         "review_decision": "",
-        "checks": [
-            {
-                "name": "reconcile",
-                "workflow_name": "Orchestrator PR Reconciliation",
-                "status": "IN_PROGRESS",
-                "conclusion": "",
-                "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
-            },
-            {
-                "name": "typing",
-                "workflow_name": "Incremental Type Check",
-                "status": "COMPLETED",
-                "conclusion": "SUCCESS",
-                "details_url": "https://example.test/check",
-            },
-        ],
+        "checks": checks,
         "failed_checks": [],
         "pending_checks": [
             {
@@ -189,7 +190,7 @@ def test_ignore_current_reconciliation_check_filters_active_workflow(
 
     filtered = orchestrator.ignore_current_reconciliation_check(pr_state)
 
-    assert filtered["checks"] == [pr_state["checks"][1]]
+    assert filtered["checks"] == [checks[1]]
     assert filtered["pending_checks"] == []
 
 

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -144,7 +144,9 @@ def test_inspect_pull_request_combines_checks_and_threads(monkeypatch) -> None:
     assert pr_state["unresolved_threads"][0]["comments"][0]["database_id"] == 321
 
 
-def test_ignore_current_reconciliation_check_filters_active_workflow(monkeypatch) -> None:
+def test_ignore_current_reconciliation_check_filters_active_workflow(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("GITHUB_RUN_ID", "12345")
     monkeypatch.setenv("GITHUB_WORKFLOW", "Orchestrator PR Reconciliation")
     monkeypatch.setenv("GITHUB_JOB", "reconcile")
@@ -180,7 +182,7 @@ def test_ignore_current_reconciliation_check_filters_active_workflow(monkeypatch
                 "status": "IN_PROGRESS",
                 "conclusion": "",
                 "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
-            }
+            },
         ],
         "unresolved_threads": [],
     }
@@ -617,7 +619,7 @@ def test_reconcile_pull_request_ignores_its_own_pending_check(
                     "status": "IN_PROGRESS",
                     "conclusion": "",
                     "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
-                }
+                },
             ],
             "failed_checks": [],
             "pending_checks": [
@@ -627,7 +629,7 @@ def test_reconcile_pull_request_ignores_its_own_pending_check(
                     "status": "IN_PROGRESS",
                     "conclusion": "",
                     "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
-                }
+                },
             ],
             "unresolved_threads": [],
         },
@@ -635,14 +637,14 @@ def test_reconcile_pull_request_ignores_its_own_pending_check(
     monkeypatch.setattr(
         orchestrator,
         "merge_pull_request",
-        lambda pr_number, merge_mode: calls.append(
-            f"merge:{pr_number}:{merge_mode}"
-        ),
+        lambda pr_number, merge_mode: calls.append(f"merge:{pr_number}:{merge_mode}"),
     )
     monkeypatch.setattr(
         orchestrator.time,
         "sleep",
-        lambda seconds: pytest.fail("should not wait on the current reconciliation check"),
+        lambda seconds: pytest.fail(
+            "should not wait on the current reconciliation check"
+        ),
     )
 
     orchestrator.reconcile_pull_request(

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -144,6 +144,53 @@ def test_inspect_pull_request_combines_checks_and_threads(monkeypatch) -> None:
     assert pr_state["unresolved_threads"][0]["comments"][0]["database_id"] == 321
 
 
+def test_ignore_current_reconciliation_check_filters_active_workflow(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "Orchestrator PR Reconciliation")
+    monkeypatch.setenv("GITHUB_JOB", "reconcile")
+
+    pr_state = {
+        "number": 7,
+        "url": "https://example.test/pr/7",
+        "is_draft": False,
+        "mergeable": "MERGEABLE",
+        "merge_state_status": "BLOCKED",
+        "review_decision": "",
+        "checks": [
+            {
+                "name": "reconcile",
+                "workflow_name": "Orchestrator PR Reconciliation",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
+            },
+            {
+                "name": "typing",
+                "workflow_name": "Incremental Type Check",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "details_url": "https://example.test/check",
+            },
+        ],
+        "failed_checks": [],
+        "pending_checks": [
+            {
+                "name": "reconcile",
+                "workflow_name": "Orchestrator PR Reconciliation",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
+            }
+        ],
+        "unresolved_threads": [],
+    }
+
+    filtered = orchestrator.ignore_current_reconciliation_check(pr_state)
+
+    assert filtered["checks"] == [pr_state["checks"][1]]
+    assert filtered["pending_checks"] == []
+
+
 def test_reconcile_pull_request_repairs_then_merges(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -525,6 +572,87 @@ def test_reconcile_pull_request_waits_for_pending_checks_before_repair(
     )
 
     assert call_order == ["wait", "resolve", "merge:13:squash"]
+
+
+def test_reconcile_pull_request_ignores_its_own_pending_check(
+    monkeypatch, tmp_path: Path
+) -> None:
+    request_dir = tmp_path / "request"
+    request_dir.mkdir()
+    plan = {"branch_name": "feat/test-branch", "commit_title": "feat: improve flow"}
+    calls: list[str] = []
+
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    monkeypatch.setenv("GITHUB_WORKFLOW", "Orchestrator PR Reconciliation")
+    monkeypatch.setenv("GITHUB_JOB", "reconcile")
+    monkeypatch.setattr(
+        orchestrator,
+        "load_orchestrator_policy",
+        lambda: {
+            "pull_request": {
+                "post_pr_reconciliation": {
+                    "enabled": True,
+                    "max_rounds": 1,
+                    "poll_interval_seconds": 0,
+                    "max_polls": 2,
+                    "auto_resolve_bot_threads": True,
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "inspect_pull_request",
+        lambda branch_name: {
+            "number": 14,
+            "url": "https://example.test/pr/14",
+            "is_draft": False,
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "review_decision": "",
+            "checks": [
+                {
+                    "name": "reconcile",
+                    "workflow_name": "Orchestrator PR Reconciliation",
+                    "status": "IN_PROGRESS",
+                    "conclusion": "",
+                    "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
+                }
+            ],
+            "failed_checks": [],
+            "pending_checks": [
+                {
+                    "name": "reconcile",
+                    "workflow_name": "Orchestrator PR Reconciliation",
+                    "status": "IN_PROGRESS",
+                    "conclusion": "",
+                    "details_url": "https://github.com/org/repo/actions/runs/12345/job/1",
+                }
+            ],
+            "unresolved_threads": [],
+        },
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "merge_pull_request",
+        lambda pr_number, merge_mode: calls.append(
+            f"merge:{pr_number}:{merge_mode}"
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator.time,
+        "sleep",
+        lambda seconds: pytest.fail("should not wait on the current reconciliation check"),
+    )
+
+    orchestrator.reconcile_pull_request(
+        request_dir,
+        plan,
+        executor_command="executor",
+        merge_mode="squash",
+    )
+
+    assert calls == ["merge:14:squash"]
 
 
 def test_reconcile_pull_request_syncs_when_branch_is_behind(

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -399,7 +399,14 @@ def test_auto_resolve_bot_threads_replies_before_resolving(monkeypatch) -> None:
                             "database_id": 987,
                             "author": "chatgpt-codex-connector",
                             "author_type": "Bot",
-                            "body": "old comment",
+                            "body": "top-level comment",
+                            "state": "SUBMITTED",
+                        },
+                        {
+                            "database_id": 654,
+                            "author": "chatgpt-codex-connector",
+                            "author_type": "Bot",
+                            "body": "reply comment",
                             "state": "SUBMITTED",
                         }
                     ],

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -65,6 +65,7 @@ def test_create_pr_body_includes_spec_and_tasks() -> None:
 
     body = orchestrator.create_pr_body(plan)
 
+    assert orchestrator.ORCHESTRATOR_MANAGED_MARKER in body
     assert "## Change spec" in body
     assert "Update PR template" in body
     assert "keep main protected" in body

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -408,7 +408,7 @@ def test_auto_resolve_bot_threads_replies_before_resolving(monkeypatch) -> None:
                             "author_type": "Bot",
                             "body": "reply comment",
                             "state": "SUBMITTED",
-                        }
+                        },
                     ],
                 }
             ],


### PR DESCRIPTION
<!-- orchestrator-managed -->

## Summary
- add a visible reply before auto-resolving bot-only review threads
- keep PR reconciliation traceable for human reviewers

## Change spec
- Problem: auto-resolved bot threads were closed without a visible explanation in the thread
- In scope: product owner orchestrator PR reconciliation for bot-only review threads
- Out of scope: human review automation or bypassing branch protections
- Source of truth: src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py, docs/operations/product-owner-orchestrator.md
- Invariants to preserve: do not auto-resolve human review comments; do not bypass checks or branch protections
- Validation plan: pytest -q tests/test_run_product_owner_orchestrator.py; incremental quality gate; incremental typecheck; docs-governance

## Governance checks
- [x] Planned from a minimal explicit spec
- [x] Scoped as bounded iterative tasks
- [x] Validation and canonical documentation considered
