### PR TITLE
feat: harden orchestrator watcher on gemini

### DIFF
--- a/.github/scripts/orchestrator-gemini-executor.sh
+++ b/.github/scripts/orchestrator-gemini-executor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <repo_root> <task_prompt_file> [attempt]" >&2
+  exit 2
+fi
+
+repo_root=$1
+task_prompt_file=$2
+attempt=${3:-1}
+
+cd "$repo_root"
+
+if ! command -v gemini >/dev/null 2>&1; then
+  echo "gemini command not found for the GitHub Actions executor." >&2
+  exit 127
+fi
+
+export GOOGLE_GENAI_USE_VERTEXAI=${GOOGLE_GENAI_USE_VERTEXAI:-1}
+export GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT:-sub403o4u0q5}
+export GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-europe-west1}
+
+gemini_model=${ASSESSMENT_ORCHESTRATOR_EXECUTOR_MODEL:-gemini-2.5-pro}
+
+if [ "${ORCHESTRATOR_EXECUTOR_PREFLIGHT:-0}" = "1" ]; then
+  exec gemini \
+    --model "$gemini_model" \
+    --skip-trust \
+    --approval-mode yolo \
+    --output-format text \
+    -p "Return exactly OK."
+fi
+
+exec gemini \
+  --model "$gemini_model" \
+  --skip-trust \
+  --approval-mode yolo \
+  --output-format text \
+  -p "$(cat "$task_prompt_file")"

--- a/.github/scripts/orchestrator-github-executor.sh
+++ b/.github/scripts/orchestrator-github-executor.sh
@@ -1,31 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 2 ]; then
-  echo "usage: $0 <repo_root> <task_prompt_file> [attempt]" >&2
-  exit 2
-fi
-
-repo_root=$1
-task_prompt_file=$2
-attempt=${3:-1}
-
-cd "$repo_root"
-
-copilot_auth_token=${COPILOT_REQUESTS_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}
-if [ -z "$copilot_auth_token" ]; then
-  echo "COPILOT_REQUESTS_TOKEN or GITHUB_TOKEN is required for the GitHub Actions executor." >&2
-  exit 2
-fi
-
-export GH_TOKEN="$copilot_auth_token"
-export GITHUB_TOKEN="$copilot_auth_token"
-
-exec copilot \
-  --model gpt-5.4 \
-  --allow-all \
-  --no-ask-user \
-  --silent \
-  --log-level error \
-  --name "orchestrator-pr-reconcile-${attempt}" \
-  -p "$(cat "$task_prompt_file")"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+exec "$script_dir/orchestrator-gemini-executor.sh" "$@"

--- a/.github/workflows/orchestrator-pr-reconcile.yml
+++ b/.github/workflows/orchestrator-pr-reconcile.yml
@@ -155,7 +155,7 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
           pip install pytest pytest-asyncio pytest-mock
-          npm install -g @github/copilot
+          npm install -g @google/gemini-cli
 
       - name: Resume orchestrator reconciliation
         env:
@@ -163,7 +163,12 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           EXECUTOR_CMD_SECRET: ${{ secrets.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
           EXECUTOR_CMD_VAR: ${{ vars.ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD }}
-          COPILOT_REQUESTS_TOKEN: ${{ secrets.COPILOT_REQUESTS_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          GOOGLE_CLOUD_LOCATION: ${{ vars.GOOGLE_CLOUD_LOCATION }}
+          GOOGLE_GENAI_USE_VERTEXAI: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+          ASSESSMENT_ORCHESTRATOR_EXECUTOR_MODEL: ${{ vars.ASSESSMENT_ORCHESTRATOR_EXECUTOR_MODEL }}
           PYTHONDONTWRITEBYTECODE: "1"
           PYTHONPATH: src
         run: |
@@ -175,7 +180,7 @@ jobs:
           fi
 
           if [ -z "$executor_command" ]; then
-            executor_command="./.github/scripts/orchestrator-github-executor.sh {repo_root} {task_prompt_file} {attempt}"
+            executor_command="./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}"
           fi
 
           export ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD="$executor_command"

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Si un documento narrativo contradice al código o a los contratos, **manda el re
 | `operations/engineering-quality-gates.md` | Política canónica de calidad de implementación |
 | `operations/product-owner-orchestrator.md` | Orquestador local desde petición de negocio hasta PR |
 | `../.github/workflows/orchestrator-pr-reconcile.yml` | Watcher automático que reanuda PRs gestionadas del orquestador |
-| `../.github/scripts/orchestrator-github-executor.sh` | Wrapper de executor para usar Copilot CLI dentro de GitHub Actions |
+| `../.github/scripts/orchestrator-gemini-executor.sh` | Wrapper de executor para usar Gemini CLI dentro de GitHub Actions |
 | `contracts/` | Contratos, matrices y plantillas de diseño |
 | `reference/generated/` | Referencia derivada o heredada no canónica |
 | `../GEMINI.md` | Adaptador para Gemini y memoria operativa en transición |

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -220,12 +220,12 @@ entries:
     source_of_truth:
       - docs/operations/product-owner-orchestrator.md
       - docs/operations/engineering-quality-gates.md
-      - .github/scripts/orchestrator-github-executor.sh
+      - .github/scripts/orchestrator-gemini-executor.sh
       - src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
     last_verified_against: 2026-05-01
     notes: Workflow que reanuda automáticamente PRs gestionadas por el orquestador cuando llegan checks, comentarios o ejecuciones manuales.
 
-  - path: .github/scripts/orchestrator-github-executor.sh
+  - path: .github/scripts/orchestrator-gemini-executor.sh
     kind: document
     title: GitHub Actions executor wrapper for the product owner orchestrator
     doc_type: operational

--- a/docs/operations/engineering-quality-gates.md
+++ b/docs/operations/engineering-quality-gates.md
@@ -98,7 +98,7 @@ La automatización no sustituye la revisión de PR:
 - `AGENTS.md` y `.github/copilot-instructions.md` remiten a esta política antes de programar con agentes;
 - la gobernanza documental sigue exigiendo actualizar la documentación canónica cuando cambian reglas, workflows o validadores.
 - el watcher `.github/workflows/orchestrator-pr-reconcile.yml`, cuando está habilitado para una PR gestionada, no sustituye estos gates: simplemente vuelve a invocar `resume-pr` para reejecutarlos y reaccionar al feedback de GitHub.
-- la configuración operativa estable del watcher incluye un executor del repo para GitHub Actions y un secret `COPILOT_REQUESTS_TOKEN`; sin esa base, el watcher puede existir pero no se considera plenamente preparado para autoreparación fiable.
+- la configuración operativa estable del watcher incluye un executor Gemini del repo para GitHub Actions y una credencial Gemini/Google válida; sin esa base, el watcher puede existir pero no se considera plenamente preparado para autoreparación fiable.
 
 ## Ejecución local recomendada
 

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -84,9 +84,10 @@ El bundle se guarda en `working/product_owner_requests/<timestamp>_<slug>/`.
 Para cada tarea:
 
 1. genera un prompt estructurado con el plan global y el task actual;
-2. invoca un ejecutor externo configurable;
-3. ejecuta validaciones estándar del repo;
-4. si falla, reintenta pasando feedback de validación a la siguiente iteración.
+2. valida la configuración mínima del executor y hace un preflight cuando el backend lo soporta;
+3. invoca un ejecutor externo configurable;
+4. ejecuta validaciones estándar del repo;
+5. si falla, reintenta pasando feedback de validación a la siguiente iteración.
 
 ### 3. Validación estándar
 
@@ -124,6 +125,12 @@ La fase post-PR **no sustituye** los controles del repo ni los rebaja. Su papel 
 7. reconsultar la PR;
 8. mergear solo cuando GitHub deja de reportar checks pendientes/fallidos y no quedan conversaciones abiertas.
 
+La sesión de reconciliación deja además artefactos de trazabilidad en `working/product_owner_requests/...`:
+
+- `reconciliation_events.jsonl` con la secuencia de polls, syncs, reparaciones y cierres automáticos;
+- `reconciliation_summary.json` con el estado final de la sesión;
+- logs separados para preflight del executor, validaciones y rondas de reparación.
+
 Por defecto puede resolver automáticamente **threads abiertos creados por bots** una vez que la rama ya no tiene checks rojos ni pendientes. Antes de cerrarlos deja una nota visible en el propio hilo explicando que el estado actual de la PR ya fue revalidado y por qué ese thread se considera cerrable. No auto-resuelve feedback humano implícitamente fuera de las reglas normales de GitHub: si la PR sigue bloqueada por requisitos externos de review o protección de rama, el merge no se fuerza.
 
 La sincronización con la base ocurre dentro del mismo circuito controlado: el orquestador trae `origin/<base_branch>` a la rama activa, vuelve a ejecutar las validaciones locales y solo hace push si la rama sigue pasando los gates. Si esa sincronización introduce un fallo, ese fallo entra como feedback de la siguiente ronda de reparación; no se salta.
@@ -142,9 +149,11 @@ Reglas de seguridad del watcher:
 - exige que la PR tenga el marcador oculto del orquestador o la label `orchestrator-managed`;
 - serializa la ejecución por número de PR para no correr dos reconciliaciones en paralelo;
 - reutiliza `resume-pr`, así que sigue pasando por tests, quality, typing, docs-governance, sync con `main` y reglas de review;
-- usa por defecto `./.github/scripts/orchestrator-github-executor.sh {repo_root} {task_prompt_file} {attempt}` como executor compatible con GitHub Actions;
+- usa por defecto `./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}` como executor compatible con GitHub Actions;
 - la regla operativa recomendada es mantener `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` configurado en GitHub Actions apuntando a ese wrapper del repo, para no depender de rutas locales o wrappers efímeros;
-- para que el executor pueda autenticarse de forma estable en GitHub Actions, el repo debe tener `COPILOT_REQUESTS_TOKEN` como secret con permiso `Copilot Requests`; si no existe, el wrapper intentará usar `GITHUB_TOKEN`, pero la configuración soportada para operación estable es el secret dedicado.
+- el wrapper del repo ejecuta `gemini-2.5-pro` por defecto y fuerza la ruta Gemini de forma coherente con el resto de scripts;
+- para que el executor pueda autenticarse de forma estable en GitHub Actions, el repo debe exponer una credencial Gemini o Google válida: `GEMINI_API_KEY`, `GOOGLE_API_KEY` o autenticación Google/Vertex habilitada con `GOOGLE_GENAI_USE_VERTEXAI=1` y credenciales de aplicación disponibles en el runner;
+- si el preflight del executor falla por credenciales o configuración, la reconciliación aborta antes de entrar en rondas largas de reparación y deja el motivo clasificado en los artefactos de sesión.
 
 ## Política configurable
 
@@ -158,6 +167,26 @@ Reglas de seguridad del watcher:
 - reconciliación post-PR (polling, rondas máximas, sync con base y resolución automática de threads de bot);
 - watcher automático de reanudación para PRs gestionadas;
 - validaciones estándar.
+
+## Clasificación de fallos operativos
+
+El orquestador separa explícitamente varias familias de fallo para evitar diagnósticos ambiguos:
+
+- `executor_auth`: credenciales inválidas o sin permiso para que el backend de agente procese requests;
+- `executor_config`: executor declarado pero mal configurado para el entorno actual;
+- `executor_missing`: binario o wrapper ausente;
+- `validation`: tests, quality, typing o docs-governance rojos;
+- `command_failure`: otros errores no clasificados todavía.
+
+La intención no es maquillar el error sino **fallar antes y con una causa accionable**.
+
+## Pendiente para cierre end-to-end
+
+El flujo ya puede operar de forma homogénea sobre Gemini también en la reconciliación automática de PRs, pero para considerar el circuito **realmente cerrado de punta a punta en GitHub Actions** sigue pendiente habilitar la credencial del executor en el repo:
+
+1. configurar en GitHub Actions una credencial válida para Gemini o Google;
+2. decidir si el watcher usará `GEMINI_API_KEY`, `GOOGLE_API_KEY` o autenticación Google/Vertex del runner;
+3. verificar con una PR gestionada real que `resume-pr` completa preflight, reparación, validación y merge sin intervención manual.
 
 ## Limitaciones deliberadas del MVP
 

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -32,6 +32,8 @@ from assessment_engine.scripts.lib.runtime_paths import ROOT
 from assessment_engine.scripts.lib.text_utils import slugify
 
 ORCHESTRATOR_MANAGED_MARKER = "<!-- orchestrator-managed -->"
+RECONCILIATION_SUMMARY_FILE = "reconciliation_summary.json"
+RECONCILIATION_TIMELINE_FILE = "reconciliation_events.jsonl"
 
 REVIEW_THREADS_QUERY = """
 query($owner:String!, $repo:String!, $number:Int!) {
@@ -272,6 +274,67 @@ def load_json_file(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+class OrchestratorCommandError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        category: str,
+        command: list[str],
+        output_path: Path,
+        raw_output: str,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.command = command
+        self.output_path = output_path
+        self.raw_output = raw_output
+
+
+def classify_command_failure(command: list[str], output: str) -> str:
+    lowered = output.lower()
+    command_text = " ".join(command).lower()
+    if (
+        "authentication failed" in lowered
+        or "please set an auth method" in lowered
+        or "gemini_api_key" in lowered
+        or "google_api_key" in lowered
+        or "google_genai_use_vertexai" in lowered
+        or "google_genai_use_gca" in lowered
+        or "vertex ai" in lowered
+        and "must specify either" in lowered
+    ):
+        return "executor_auth"
+    if "required for the github actions executor" in lowered:
+        return "executor_config"
+    if "no such file or directory" in lowered or "command not found" in lowered:
+        return "executor_missing"
+    if (
+        "pytest" in command_text
+        or "quality_gate" in command_text
+        or "typecheck" in command_text
+    ):
+        return "validation"
+    return "command_failure"
+
+
+def build_command_failure_message(
+    category: str, command: list[str], output_path: Path
+) -> str:
+    prefix = {
+        "executor_auth": "Fallo de autenticación del executor.",
+        "executor_config": "Configuración inválida del executor.",
+        "executor_missing": "El comando del executor no está disponible en este entorno.",
+        "validation": "Falló una validación estándar del repo.",
+        "command_failure": "Falló un comando del orquestador.",
+    }.get(category, "Falló un comando del orquestador.")
+    return (
+        f"{prefix} Categoría: {category}. "
+        f"Comando: {' '.join(command)}. "
+        f"Log: {output_path}"
+    )
+
+
 def run_command(command: list[str], *, output_path: Path) -> None:
     env = build_runtime_env()
     env["PYTHONPATH"] = str(ROOT / "src")
@@ -286,7 +349,83 @@ def run_command(command: list[str], *, output_path: Path) -> None:
     output = (result.stdout or "") + ("\n" + result.stderr if result.stderr else "")
     output_path.write_text(output, encoding="utf-8")
     if result.returncode != 0:
-        raise RuntimeError(output.strip() or f"Fallo ejecutando {' '.join(command)}")
+        category = classify_command_failure(command, output)
+        raise OrchestratorCommandError(
+            build_command_failure_message(category, command, output_path),
+            category=category,
+            command=command,
+            output_path=output_path,
+            raw_output=output.strip() or f"Fallo ejecutando {' '.join(command)}",
+        )
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def append_reconciliation_event(request_dir: Path, payload: dict[str, Any]) -> None:
+    event = {"timestamp_utc": datetime.now(timezone.utc).isoformat(), **payload}
+    timeline_path = request_dir / RECONCILIATION_TIMELINE_FILE
+    with timeline_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+
+def write_reconciliation_summary(request_dir: Path, payload: dict[str, Any]) -> None:
+    summary = {"updated_at_utc": datetime.now(timezone.utc).isoformat(), **payload}
+    write_json(request_dir / RECONCILIATION_SUMMARY_FILE, summary)
+
+
+def executor_uses_github_wrapper(command_template: str) -> bool:
+    return (
+        "orchestrator-gemini-executor.sh" in command_template
+        or "orchestrator-github-executor.sh" in command_template
+    )
+
+
+def validate_executor_configuration(command_template: str) -> None:
+    if not executor_uses_github_wrapper(command_template):
+        return
+
+    vertex_selector = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").strip().lower()
+    gca_selector = os.environ.get("GOOGLE_GENAI_USE_GCA", "").strip().lower()
+    has_api_key = bool(
+        os.environ.get("GEMINI_API_KEY", "").strip()
+        or os.environ.get("GOOGLE_API_KEY", "").strip()
+    )
+
+    if vertex_selector in {"0", "false", "no"} and not gca_selector and not has_api_key:
+        raise RuntimeError(
+            "El executor de Gemini requiere GEMINI_API_KEY, GOOGLE_API_KEY o habilitar autenticación Google."
+        )
+
+
+def preflight_executor(request_dir: Path, command_template: str) -> None:
+    validate_executor_configuration(command_template)
+    if not executor_uses_github_wrapper(command_template):
+        return
+
+    preflight_prompt_path = request_dir / "executor_preflight_prompt.md"
+    preflight_prompt_path.write_text(
+        "Executor preflight. Return exactly OK and do not modify the repository.\n",
+        encoding="utf-8",
+    )
+    output_path = request_dir / "executor_preflight.log"
+    env_var = os.environ.get("ORCHESTRATOR_EXECUTOR_PREFLIGHT", "")
+    try:
+        os.environ["ORCHESTRATOR_EXECUTOR_PREFLIGHT"] = "1"
+        run_command(
+            build_executor_args(
+                command_template,
+                task_prompt_file=preflight_prompt_path,
+                attempt=0,
+            ),
+            output_path=output_path,
+        )
+    finally:
+        if env_var:
+            os.environ["ORCHESTRATOR_EXECUTOR_PREFLIGHT"] = env_var
+        else:
+            os.environ.pop("ORCHESTRATOR_EXECUTOR_PREFLIGHT", None)
 
 
 def run_standard_validations(request_dir: Path) -> None:
@@ -695,6 +834,17 @@ def repair_pull_request(
     round_number: int,
     additional_feedback: str | None = None,
 ) -> bool:
+    append_reconciliation_event(
+        request_dir,
+        {
+            "event": "repair_started",
+            "round_number": round_number,
+            "pr_number": pr_state["number"],
+            "failed_checks": len(pr_state["failed_checks"]),
+            "pending_checks": len(pr_state["pending_checks"]),
+            "unresolved_threads": len(pr_state["unresolved_threads"]),
+        },
+    )
     feedback_payload = build_pr_feedback(pr_state)
     if additional_feedback:
         feedback_payload["additional_feedback"] = additional_feedback
@@ -710,16 +860,43 @@ def repair_pull_request(
         task_prompt_file=prompt_path,
         attempt=round_number,
     )
-    run_command(
-        executor_args,
-        output_path=request_dir / f"pr_reconciliation_{round_number}.log",
-    )
+    try:
+        run_command(
+            executor_args,
+            output_path=request_dir / f"pr_reconciliation_{round_number}.log",
+        )
+    except OrchestratorCommandError as exc:
+        append_reconciliation_event(
+            request_dir,
+            {
+                "event": "repair_failed",
+                "round_number": round_number,
+                "failure_category": exc.category,
+                "log_path": str(exc.output_path),
+            },
+        )
+        raise
     if not has_worktree_changes():
         run_standard_validations(request_dir)
+        append_reconciliation_event(
+            request_dir,
+            {
+                "event": "repair_noop",
+                "round_number": round_number,
+            },
+        )
         return False
     run_standard_validations(request_dir)
     create_commit(create_followup_commit_title(plan, round_number))
     push_branch(plan["branch_name"])
+    append_reconciliation_event(
+        request_dir,
+        {
+            "event": "repair_committed",
+            "round_number": round_number,
+            "branch_name": plan["branch_name"],
+        },
+    )
     return True
 
 
@@ -776,6 +953,17 @@ def reconcile_pull_request(
     auto_resolve_bot = bool(reconciliation.get("auto_resolve_bot_threads", True))
     sync_with_base_branch = bool(reconciliation.get("sync_with_base_branch", True))
     repair_rounds = 0
+    write_reconciliation_summary(
+        request_dir,
+        {
+            "status": "running",
+            "branch_name": plan["branch_name"],
+            "merge_mode": merge_mode,
+            "allow_merge": allow_merge,
+            "max_rounds": max_rounds,
+            "max_polls": max_polls,
+        },
+    )
 
     for poll_index in range(1, max_polls + 1):
         pr_state = ignore_current_reconciliation_check(
@@ -785,8 +973,29 @@ def reconcile_pull_request(
             json.dumps(pr_state, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        append_reconciliation_event(
+            request_dir,
+            {
+                "event": "poll",
+                "poll_index": poll_index,
+                "pr_number": pr_state["number"],
+                "mergeable": pr_state["mergeable"],
+                "merge_state_status": pr_state["merge_state_status"],
+                "failed_checks": len(pr_state["failed_checks"]),
+                "pending_checks": len(pr_state["pending_checks"]),
+                "unresolved_threads": len(pr_state["unresolved_threads"]),
+            },
+        )
 
         if sync_with_base_branch and pr_state["merge_state_status"] == "BEHIND":
+            append_reconciliation_event(
+                request_dir,
+                {
+                    "event": "sync_started",
+                    "poll_index": poll_index,
+                    "base_branch": pr_state["base_ref"],
+                },
+            )
             sync_feedback = sync_branch_with_base(
                 request_dir,
                 plan,
@@ -809,11 +1018,33 @@ def reconcile_pull_request(
                         f"locales fallando: {sync_feedback}"
                     ),
                 )
+            else:
+                append_reconciliation_event(
+                    request_dir,
+                    {
+                        "event": "sync_completed",
+                        "poll_index": poll_index,
+                        "base_branch": pr_state["base_ref"],
+                    },
+                )
             continue
 
         if is_pull_request_ready_for_merge(pr_state):
             if allow_merge:
                 merge_pull_request(pr_state["number"], merge_mode)
+            write_reconciliation_summary(
+                request_dir,
+                {
+                    "status": "merged" if allow_merge else "ready_without_merge",
+                    "branch_name": plan["branch_name"],
+                    "pr_number": pr_state["number"],
+                    "repair_rounds": repair_rounds,
+                    "final_state": {
+                        "mergeable": pr_state["mergeable"],
+                        "merge_state_status": pr_state["merge_state_status"],
+                    },
+                },
+            )
             return
 
         if pr_state["pending_checks"]:
@@ -830,6 +1061,14 @@ def reconcile_pull_request(
             ]
             if bot_only:
                 auto_resolve_bot_threads(pr_state)
+                append_reconciliation_event(
+                    request_dir,
+                    {
+                        "event": "bot_threads_resolved",
+                        "poll_index": poll_index,
+                        "count": len(bot_only),
+                    },
+                )
                 continue
 
         if pr_state["failed_checks"] or pr_state["unresolved_threads"]:
@@ -851,6 +1090,15 @@ def reconcile_pull_request(
             break
         time.sleep(poll_interval_seconds)
 
+    write_reconciliation_summary(
+        request_dir,
+        {
+            "status": "timed_out",
+            "branch_name": plan["branch_name"],
+            "repair_rounds": repair_rounds,
+            "last_poll_index": max_polls,
+        },
+    )
     raise RuntimeError(
         "La PR no llegó a un estado mergeable dentro del tiempo de reconciliación."
     )
@@ -934,6 +1182,7 @@ def execute_plan(
 ) -> None:
     policy = load_orchestrator_policy()
     max_attempts = int(policy.get("execution", {}).get("max_attempts_per_task", 3))
+    preflight_executor(request_dir, executor_command)
 
     ensure_branch(plan["branch_name"])
 
@@ -1005,6 +1254,7 @@ def resume_pull_request(
     plan = prepare_resume_plan(policy, pr_state)
     save_plan_bundle(request_dir, request_text, plan)
     executor_command = resolve_executor_command(args.executor_command)
+    preflight_executor(request_dir, executor_command)
     reconcile_pull_request(
         request_dir,
         plan,

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 import pytest
@@ -43,6 +45,15 @@ def test_build_executor_args_supports_placeholders() -> None:
     assert "--workspace" in args
     assert "/tmp/task.md" in args
     assert "2" in args
+
+
+def test_classify_command_failure_detects_executor_auth() -> None:
+    category = orchestrator.classify_command_failure(
+        ["gemini", "-p", "prompt"],
+        "Please set an Auth method in your settings or specify GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA.",
+    )
+
+    assert category == "executor_auth"
 
 
 def test_resolve_resume_selector_prefers_branch() -> None:
@@ -268,6 +279,12 @@ def test_reconcile_pull_request_repairs_then_merges(
     )
 
     assert call_order == ["repair", "merge:9:squash"]
+    summary = json.loads(
+        (request_dir / orchestrator.RECONCILIATION_SUMMARY_FILE).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["status"] == "merged"
 
 
 def test_repair_pull_request_allows_noop_when_validations_pass(
@@ -333,6 +350,55 @@ def test_repair_pull_request_allows_noop_when_validations_pass(
     assert changed is False
     assert prompt_path.read_text(encoding="utf-8") == "prompt"
     assert "validated" in outputs
+
+
+def test_validate_executor_configuration_rejects_disabled_google_auth_without_keys(
+    monkeypatch, tmp_path: Path
+) -> None:
+    request_dir = tmp_path / "request"
+    request_dir.mkdir()
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_GENAI_USE_GCA", raising=False)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "0")
+
+    with pytest.raises(RuntimeError, match="El executor de Gemini requiere"):
+        orchestrator.preflight_executor(
+            request_dir,
+            "./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}",
+        )
+
+
+def test_preflight_executor_runs_wrapper_probe(monkeypatch, tmp_path: Path) -> None:
+    request_dir = tmp_path / "request"
+    request_dir.mkdir()
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    calls: list[tuple[list[str], Path, str | None]] = []
+
+    def fake_run_command(command: list[str], *, output_path: Path) -> None:
+        calls.append(
+            (
+                command,
+                output_path,
+                os.environ.get("ORCHESTRATOR_EXECUTOR_PREFLIGHT"),
+            )
+        )
+
+    monkeypatch.setattr(orchestrator, "run_command", fake_run_command)
+
+    orchestrator.preflight_executor(
+        request_dir,
+        "./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}",
+    )
+
+    assert calls
+    assert calls[0][2] == "1"
+    assert calls[0][1].name == "executor_preflight.log"
+    assert (
+        (request_dir / "executor_preflight_prompt.md")
+        .read_text(encoding="utf-8")
+        .startswith("Executor preflight.")
+    )
 
 
 def test_reconcile_pull_request_auto_resolves_bot_threads(


### PR DESCRIPTION
## Summary

- migrate the GitHub Actions orchestrator executor path from Copilot/GPT-5.4 to Gemini
- add executor preflight, failure classification, and reconciliation observability
- document the remaining operational step to validate the full end-to-end flow in GitHub Actions

## What changed

- added `./.github/scripts/orchestrator-gemini-executor.sh` as the default GitHub Actions executor wrapper
- kept `./.github/scripts/orchestrator-github-executor.sh` as a compatibility shim to the Gemini wrapper
- updated `orchestrator-pr-reconcile.yml` to install `@google/gemini-cli` and read Gemini/Google credentials
- hardened `run_product_owner_orchestrator.py` with:
  - executor preflight
  - explicit failure categories
  - reconciliation timeline and summary artifacts
- added regression coverage for Gemini executor auth/config paths and reconciliation summary generation
- aligned the operational docs and documentation map with the new Gemini-based watcher path

## Validation

- `PYTHONPATH=src /home/jsanchhi/.venv/bin/pytest tests/test_run_product_owner_orchestrator.py -q`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_quality_gate.py --repo-root . --path src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py --path tests/test_run_product_owner_orchestrator.py`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_typecheck.py --repo-root . --path src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py --path tests/test_run_product_owner_orchestrator.py`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/validate_documentation_governance.py --repo-root . --documentation-map docs/documentation-map.yaml`

## Follow-up

- configure and validate the definitive Gemini credential path in GitHub Actions as the standard production setup
- run one managed PR end-to-end to confirm preflight, repair, validation, and merge without manual intervention
