### PR TITLE
feat: add friendly po-run wrapper

### DIFF
--- a/bin/po-run
+++ b/bin/po-run
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+orchestrator_script="$repo_root/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./bin/po-run [--plan|--run] [--request-file PATH] [--executor-command CMD]
+               [--allow-dirty] [--skip-auto-merge] [--yes] [request...]
+
+Examples:
+  ./bin/po-run "Quiero que el informe global priorice mejor los riesgos criticos"
+  ./bin/po-run --plan "Quiero endurecer la reconciliacion automatica de PRs"
+  ./bin/po-run --request-file ./request.txt
+  ./bin/po-run --executor-command "./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}" "Quiero..."
+EOF
+}
+
+die() {
+  printf 'po-run: %s\n' "$1" >&2
+  exit 2
+}
+
+resolve_python_bin() {
+  if [[ -n "${ASSESSMENT_ENGINE_PYTHON_BIN:-}" ]]; then
+    printf '%s\n' "$ASSESSMENT_ENGINE_PYTHON_BIN"
+    return
+  fi
+  if [[ -x "$repo_root/.venv/bin/python" ]]; then
+    printf '%s\n' "$repo_root/.venv/bin/python"
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return
+  fi
+  die "No encuentro un interprete Python. Usa ASSESSMENT_ENGINE_PYTHON_BIN o crea ./.venv."
+}
+
+default_executor_command() {
+  if [[ -n "${ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD:-}" ]]; then
+    printf '%s\n' "$ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD"
+    return
+  fi
+
+  local repo_wrapper="$repo_root/.github/scripts/orchestrator-gemini-executor.sh"
+  if [[ -x "$repo_wrapper" ]]; then
+    printf '%s\n' "$repo_wrapper {repo_root} {task_prompt_file} {attempt}"
+  fi
+}
+
+mode="run"
+request=""
+request_file=""
+executor_command=""
+allow_dirty=0
+skip_auto_merge=0
+skip_confirmation=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan)
+      mode="plan"
+      shift
+      ;;
+    --run)
+      mode="run"
+      shift
+      ;;
+    --request-file)
+      [[ $# -ge 2 ]] || die "--request-file necesita una ruta."
+      request_file="$2"
+      shift 2
+      ;;
+    --executor-command)
+      [[ $# -ge 2 ]] || die "--executor-command necesita un valor."
+      executor_command="$2"
+      shift 2
+      ;;
+    --allow-dirty)
+      allow_dirty=1
+      shift
+      ;;
+    --skip-auto-merge)
+      skip_auto_merge=1
+      shift
+      ;;
+    --yes)
+      skip_confirmation=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      die "Flag no reconocida: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -z "$request_file" ]]; then
+  request="$*"
+fi
+
+if [[ -z "${request//[[:space:]]/}" && -z "$request_file" ]]; then
+  if [[ -t 0 && -t 1 ]]; then
+    printf 'Peticion para el orquestador: ' >&2
+    IFS= read -r request
+  fi
+fi
+
+if [[ -z "${request//[[:space:]]/}" && -z "$request_file" ]]; then
+  die "Debes indicar una peticion como argumento o con --request-file."
+fi
+
+if [[ -n "$request_file" && ! -f "$request_file" ]]; then
+  die "No existe el fichero de peticion: $request_file"
+fi
+
+if [[ ! -f "$orchestrator_script" ]]; then
+  die "No encuentro $orchestrator_script"
+fi
+
+python_bin=$(resolve_python_bin)
+
+if [[ "$mode" == "run" && -z "$executor_command" ]]; then
+  executor_command=$(default_executor_command)
+fi
+
+if [[ "$mode" == "run" && -z "$executor_command" ]]; then
+  die "No hay executor configurado. Usa --executor-command o exporta ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD."
+fi
+
+if [[ "$mode" == "run" && "$skip_confirmation" -eq 0 && -t 0 && -t 1 ]]; then
+  printf 'Modo: %s\n' "$mode" >&2
+  if [[ -n "$request_file" ]]; then
+    printf 'Peticion desde fichero: %s\n' "$request_file" >&2
+  else
+    printf 'Peticion: %s\n' "$request" >&2
+  fi
+  printf 'Python: %s\n' "$python_bin" >&2
+  printf 'Executor: %s\n' "$executor_command" >&2
+  read -r -p "Lanzar ahora el orquestador? [Y/n] " answer
+  if [[ -n "${answer:-}" && ! "$answer" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+    printf 'Cancelado.\n' >&2
+    exit 0
+  fi
+fi
+
+cmd=("$python_bin" "$orchestrator_script" "$mode")
+if [[ -n "$request_file" ]]; then
+  cmd+=("--request-file" "$request_file")
+else
+  cmd+=("--request" "$request")
+fi
+if [[ "$mode" == "run" ]]; then
+  cmd+=("--executor-command" "$executor_command")
+fi
+if [[ "$allow_dirty" -eq 1 ]]; then
+  cmd+=("--allow-dirty")
+fi
+if [[ "$mode" == "run" && "$skip_auto_merge" -eq 1 ]]; then
+  cmd+=("--skip-auto-merge")
+fi
+
+printf '==> Ejecutando product owner orchestrator (%s)\n' "$mode" >&2
+exec "${cmd[@]}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Si un documento narrativo contradice al código o a los contratos, **manda el re
 | `operations/agentic-development-workflow.md` | Flujo canónico para programar con agentes |
 | `operations/engineering-quality-gates.md` | Política canónica de calidad de implementación |
 | `operations/product-owner-orchestrator.md` | Orquestador local desde petición de negocio hasta PR |
+| `../bin/po-run` | Wrapper friendly para lanzar el orquestador local desde terminal |
 | `../.github/workflows/orchestrator-pr-reconcile.yml` | Watcher automático que reanuda PRs gestionadas del orquestador |
 | `../.github/scripts/orchestrator-gemini-executor.sh` | Wrapper de executor para usar Gemini CLI dentro de GitHub Actions |
 | `contracts/` | Contratos, matrices y plantillas de diseño |
@@ -106,6 +107,7 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - ya existe una guía canónica para exigir spec mínima y alcance explícito en cambios asistidos por agentes;
 - la plantilla de PR ya obliga también a explicitar checks de coherencia cuando un cambio toca semántica de assessment o salidas cliente-facing;
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
+- ya existe `./bin/po-run` como entrada corta e interactiva para lanzar ese flujo desde terminal;
 - ya existe un watcher de GitHub que puede reanudar PRs gestionadas del orquestador cuando fallan checks o aparece feedback nuevo;
 - ya existe un executor del repo compatible con GitHub Actions para que el watcher no dependa de rutas locales;
 - el baseline smoke de `smoke_ivirma` ya está cerrado para T5, global, comercial y web;

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -240,6 +240,22 @@ entries:
     last_verified_against: 2026-05-01
     notes: Wrapper del repo que autentica Copilot CLI en GitHub Actions y ejecuta el prompt de reconciliación contra la rama activa.
 
+  - path: bin/po-run
+    kind: document
+    title: Friendly product owner orchestrator wrapper
+    doc_type: operational
+    status: Verified
+    owner: docs-governance
+    applies_to:
+      - humans
+      - ai-agents
+    source_of_truth:
+      - docs/operations/product-owner-orchestrator.md
+      - src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+      - .github/scripts/orchestrator-gemini-executor.sh
+    last_verified_against: 2026-05-01
+    notes: Wrapper corto e interactivo para lanzar plan/run del orquestador local con defaults razonables de Python y executor.
+
   - path: docs/SYSTEM_ARCHITECTURE.md
     kind: document
     title: System architecture
@@ -636,6 +652,7 @@ entries:
       - humans
       - ai-agents
     source_of_truth:
+      - bin/po-run
       - engine_config/policies/orchestrator_policy.json
       - engine_config/runtime_manifest.json
       - src/assessment_engine/scripts/lib/product_owner_models.py
@@ -645,6 +662,7 @@ entries:
       - .github/workflows/quality.yml
       - .github/workflows/typing.yml
     review_when_source_changes:
+      - bin/po-run
       - engine_config/policies/orchestrator_policy.json
       - engine_config/runtime_manifest.json
       - src/assessment_engine/scripts/lib/product_owner_models.py

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -56,6 +56,7 @@ Esta carpeta reúne la documentación operativa mínima de `assessment-engine`: 
 - la suite incluye ahora tests de coherencia transversal para score, banda, color y target del payload global;
 - el flujo de trabajo con agentes ya tiene una guía canónica de spec mínima, alcance e invariantes antes de programar;
 - ya existe un MVP de orquestador local PO-to-PR con planning, ejecución iterativa y PR automática sobre backend de agente configurable;
+- existe `./bin/po-run` como entrypoint friendly para lanzar ese orquestador desde terminal sin recordar el path largo del runner;
 - la suite actual incluye tests de entorno, contratos, schemas, render y utilidades.
 
 ## Flujo de validación actual

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -2,6 +2,7 @@
 status: Verified
 owner: docs-governance
 source_of_truth:
+  - ../../bin/po-run
   - ../../engine_config/policies/orchestrator_policy.json
   - ../../engine_config/runtime_manifest.json
   - ../../src/assessment_engine/scripts/lib/product_owner_models.py
@@ -55,6 +56,20 @@ python src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py run
   --request-file ./request.txt \
   --executor-command "mi-agente-coder --repo {repo_root} --task-file {task_prompt_file}"
 ```
+
+Para uso diario local existe además un wrapper más friendly:
+
+```bash
+./bin/po-run "Quiero que el informe global priorice los riesgos criticos de continuidad"
+./bin/po-run --plan "Quiero endurecer la reconciliacion automatica de PRs"
+```
+
+Ese wrapper:
+
+- usa `./.venv/bin/python` cuando existe y, si no, cae a `python`/`python3`;
+- permite pasar la petición inline o con `--request-file`;
+- pide confirmación interactiva antes de un `run` cuando se ejecuta en TTY;
+- y, si no se le pasa `--executor-command`, intenta reutilizar `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` o el wrapper local `./.github/scripts/orchestrator-gemini-executor.sh`.
 
 También puede **reanudar una PR existente** para seguir la reconciliación:
 

--- a/tests/test_po_run_wrapper.py
+++ b/tests/test_po_run_wrapper.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = REPO_ROOT / "bin" / "po-run"
+ORCHESTRATOR = (
+    REPO_ROOT / "src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py"
+)
+DEFAULT_EXECUTOR = (
+    f"{REPO_ROOT / '.github/scripts/orchestrator-gemini-executor.sh'} "
+    "{repo_root} {task_prompt_file} {attempt}"
+)
+
+
+def _ensure_wrapper_is_executable() -> None:
+    WRAPPER.chmod(0o755)
+
+
+def _write_fake_python(tmp_path: Path) -> tuple[Path, Path]:
+    capture_path = tmp_path / "captured_args.bin"
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        ': "${PO_RUN_CAPTURE_FILE:?}"\n'
+        'printf \'%s\\0\' "$@" > "$PO_RUN_CAPTURE_FILE"\n',
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    return fake_python, capture_path
+
+
+def _read_captured_args(path: Path) -> list[str]:
+    return [item for item in path.read_text(encoding="utf-8").split("\0") if item]
+
+
+def test_po_run_wrapper_builds_run_command_with_default_executor(
+    tmp_path: Path,
+) -> None:
+    _ensure_wrapper_is_executable()
+    fake_python, capture_path = _write_fake_python(tmp_path)
+    env = os.environ.copy()
+    env["ASSESSMENT_ENGINE_PYTHON_BIN"] = str(fake_python)
+    env["PO_RUN_CAPTURE_FILE"] = str(capture_path)
+    env.pop("ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD", None)
+
+    result = subprocess.run(
+        [str(WRAPPER), "Quiero mejorar la UX del orquestador"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert _read_captured_args(capture_path) == [
+        str(ORCHESTRATOR),
+        "run",
+        "--request",
+        "Quiero mejorar la UX del orquestador",
+        "--executor-command",
+        DEFAULT_EXECUTOR,
+    ]
+
+
+def test_po_run_wrapper_builds_plan_command_without_executor(tmp_path: Path) -> None:
+    _ensure_wrapper_is_executable()
+    fake_python, capture_path = _write_fake_python(tmp_path)
+    env = os.environ.copy()
+    env["ASSESSMENT_ENGINE_PYTHON_BIN"] = str(fake_python)
+    env["PO_RUN_CAPTURE_FILE"] = str(capture_path)
+
+    result = subprocess.run(
+        [str(WRAPPER), "--plan", "Quiero revisar la spec minima"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert _read_captured_args(capture_path) == [
+        str(ORCHESTRATOR),
+        "plan",
+        "--request",
+        "Quiero revisar la spec minima",
+    ]
+
+
+def test_po_run_wrapper_rejects_missing_request_noninteractive(tmp_path: Path) -> None:
+    _ensure_wrapper_is_executable()
+    fake_python, capture_path = _write_fake_python(tmp_path)
+    env = os.environ.copy()
+    env["ASSESSMENT_ENGINE_PYTHON_BIN"] = str(fake_python)
+    env["PO_RUN_CAPTURE_FILE"] = str(capture_path)
+
+    result = subprocess.run(
+        [str(WRAPPER), "--plan"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Debes indicar una peticion" in result.stderr
+    assert not capture_path.exists()


### PR DESCRIPTION
## Summary
- adds `./bin/po-run` as a short, friendlier entrypoint for the local product owner orchestrator
- defaults to the repo virtualenv and local Gemini executor wrapper when available

## Change spec
- Problem: launching the PO-to-PR flow required remembering the long Python entrypoint and executor flags
- In scope: add a terminal-friendly wrapper, document it, and cover it with tests
- Out of scope: changing orchestrator planning logic or GitHub reconciliation policy
- Source of truth: `docs/operations/product-owner-orchestrator.md`, `src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py`, `.github/scripts/orchestrator-gemini-executor.sh`
- Invariants to preserve: the real orchestration still runs through `run_product_owner_orchestrator.py`; repo validation and PR merge rules stay unchanged
- Validation plan: wrapper help smoke test, `pytest` for wrapper/orchestrator tests, incremental quality, incremental typecheck, docs governance

## Documentation impact
- [x] I reviewed whether this change affects architecture, contracts, operations, CI, prompts, or onboarding
- [x] I updated the canonical documentation when needed
- [x] I updated `docs/documentation-map.yaml` when a document changed state, scope, or destination
- [ ] If no documentation change was needed, I explained why below

## Validation
- [x] I ran the relevant local validation for my change
- [x] I checked whether this change depends on artifacts in `working/`

## Governance checks
- [x] I did not introduce new source-of-truth content only in agent-specific files
- [x] This change had a minimal explicit spec before implementation (problem, scope, source of truth, invariants, validation)
- [x] The change scope is intentionally bounded and does not mix unrelated redesigns unnecessarily
- [x] I reviewed whether the change duplicates existing logic or creates another source of truth
- [x] I encoded important implementation rules in code, tests, schemas, or workflows instead of leaving them only in prompts or tribal knowledge
- [x] I kept payload/schema changes aligned with their consuming renderers or updated the related contract docs
- [x] If a source-linked documentation rule applied, I updated one of the required canonical docs

## Documentation notes
- Added the wrapper to the product owner orchestrator docs, operations overview, docs index, and documentation map so the shorter entrypoint is discoverable and governed.
