### PR TITLE
refactor: reuse global band helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - la puerta incremental de calidad ya puede bloquear deuda nueva en la superficie viva;
 - la puerta incremental de tipado ya puede bloquear deuda nueva en la superficie viva;
 - ya existe una guía canónica para exigir spec mínima y alcance explícito en cambios asistidos por agentes;
+- la semántica global de score, banda, color y target ya documenta que el builder consume `global_maturity_policy.py` y no una reinterpretación local propia;
 - la plantilla de PR ya obliga también a explicitar checks de coherencia cuando un cambio toca semántica de assessment o salidas cliente-facing;
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
 - ya existe `./bin/po-run` como entrada corta e interactiva para lanzar ese flujo desde terminal;

--- a/docs/architecture/global-commercial-pipelines.md
+++ b/docs/architecture/global-commercial-pipelines.md
@@ -89,7 +89,7 @@ El builder:
 - extrae principios de arquitectura e implicaciones operativas si existen;
 - genera la consolidación global exclusivamente desde blueprints de torre disponibles.
 
-Además, la ruta activa ya debe reutilizar helpers compartidos para la semántica de madurez cuando necesita traducir score numérico a banda cualitativa. El builder global no debería volver a introducir una policy paralela escondida en la propia capa de consolidación.
+Además, la ruta activa ya debe reutilizar helpers compartidos para la semántica de madurez cuando necesita traducir score numérico a banda cualitativa. En la consolidación global, `build_global_report_payload.py` consume `src/assessment_engine/scripts/lib/global_maturity_policy.py` para score, target, color y banda, y esa política global sigue delegando los umbrales cualitativos en `src/assessment_engine/scripts/lib/maturity_band.py`. El builder global no debería volver a introducir una policy paralela escondida en la propia capa de consolidación ni depender directamente de dos capas de traducción distintas para la misma banda.
 
 ### Decisión arquitectónica relevante
 

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -982,7 +982,7 @@ entries:
       - src/assessment_engine/scripts/render_web_presentation.py
       - tests/test_global_coherence.py
     last_verified_against: 2026-05-01
-    notes: Helper compartido para score, banda, color y target del dominio global, usado para evitar duplicaciones semánticas entre builder y renderizadores.
+    notes: Helper compartido para score, banda, color y target del dominio global, usado para evitar duplicaciones semánticas entre builder y renderizadores; el builder global ya lo consume directamente para evitar reinterpretaciones locales de la banda.
 
   - path: src/assessment_engine/scripts/lib/maturity_band.py
     kind: document
@@ -998,12 +998,11 @@ entries:
       - src/assessment_engine/scripts/run_scoring.py
       - src/assessment_engine/scripts/run_executive_annex_synthesizer.py
       - src/assessment_engine/scripts/render_tower_blueprint.py
-      - src/assessment_engine/scripts/build_global_report_payload.py
       - src/assessment_engine/scripts/render_web_presentation.py
       - tests/test_maturity_band.py
       - tests/test_maturity_band_characterization.py
     last_verified_against: 2026-05-01
-    notes: Fuente única de verdad para traducir score numérico a banda cualitativa en scoring, annex, blueprint, global y web.
+    notes: Fuente única de verdad para traducir score numérico a banda cualitativa en scoring, annex, blueprint y web; la capa global la consume a través de `global_maturity_policy.py` para no duplicar dependencias semánticas.
 
   - path: GEMINI.md
     kind: document

--- a/src/assessment_engine/scripts/build_global_report_payload.py
+++ b/src/assessment_engine/scripts/build_global_report_payload.py
@@ -17,11 +17,8 @@ from assessment_engine.scripts.lib.client_intelligence import (
 from assessment_engine.scripts.lib.global_maturity_policy import (
     average_pillar_score,
     average_pillar_target,
+    band_for_score,
     status_color_for_score,
-)
-from assessment_engine.scripts.lib.maturity_band import (
-    GLOBAL_MATURITY_BANDS,
-    resolve_maturity_band,
 )
 
 TOWER_NAMES_MAP = {
@@ -102,10 +99,7 @@ def build_global_payload(client_dir: Path, client_name: str) -> dict[str, Any] |
                 "id": tid,
                 "name": tname,
                 "score": f"{avg_score:.1f}",
-                "band": resolve_maturity_band(
-                    avg_score,
-                    GLOBAL_MATURITY_BANDS,
-                )["label"],
+                "band": band_for_score(avg_score),
                 "status_color": status_color_for_score(avg_score),
                 "executive_message": data.get("executive_snapshot", {}).get(
                     "bottom_line", ""


### PR DESCRIPTION
## Summary
- use the shared global maturity helper to derive the band in `build_global_report_payload.py`
- remove the direct dependency on the generic maturity band helper from this global builder

## Testing
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python -m pytest tests/test_build_global_report_payload.py tests/test_global_coherence.py -q`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_quality_gate.py --repo-root . --path src/assessment_engine/scripts/build_global_report_payload.py`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_typecheck.py --repo-root . --path src/assessment_engine/scripts/build_global_report_payload.py`