### PR TITLE
fix: bound orchestrator executor runs

### DIFF
--- a/bin/po-run
+++ b/bin/po-run
@@ -137,6 +137,7 @@ if [[ ! -f "$orchestrator_script" ]]; then
 fi
 
 python_bin=$(resolve_python_bin)
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
 
 if [[ "$mode" == "run" && -z "$executor_command" ]]; then
   executor_command=$(default_executor_command)

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,7 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - la plantilla de PR ya obliga también a explicitar checks de coherencia cuando un cambio toca semántica de assessment o salidas cliente-facing;
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
 - ya existe `./bin/po-run` como entrada corta e interactiva para lanzar ese flujo desde terminal;
+- el orquestador local ya acota los `run` del executor con timeout explícito y evita que la propia ejecución ensucie el worktree con `__pycache__/`;
 - ya existe un watcher de GitHub que puede reanudar PRs gestionadas del orquestador cuando fallan checks o aparece feedback nuevo;
 - ya existe un executor del repo compatible con GitHub Actions para que el watcher no dependa de rutas locales;
 - el baseline smoke de `smoke_ivirma` ya está cerrado para T5, global, comercial y web;

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -100,9 +100,11 @@ Para cada tarea:
 
 1. genera un prompt estructurado con el plan global y el task actual;
 2. valida la configuración mínima del executor y hace un preflight cuando el backend lo soporta;
-3. invoca un ejecutor externo configurable;
+3. invoca un ejecutor externo configurable con timeout explícito para que un backend colgado no bloquee la sesión indefinidamente;
 4. ejecuta validaciones estándar del repo;
 5. si falla, reintenta pasando feedback de validación a la siguiente iteración.
+
+El wrapper `./bin/po-run` exporta además `PYTHONDONTWRITEBYTECODE=1` por defecto para no ensuciar el worktree con `__pycache__/` durante la propia ejecución del orquestador.
 
 ### 3. Validación estándar
 
@@ -182,6 +184,7 @@ Reglas de seguridad del watcher:
 - modo de auto-merge;
 - reconciliación post-PR (polling, rondas máximas, sync con base y resolución automática de threads de bot);
 - watcher automático de reanudación para PRs gestionadas;
+- timeouts del executor, del preflight y de las validaciones;
 - validaciones estándar.
 
 ## Clasificación de fallos operativos
@@ -191,6 +194,7 @@ El orquestador separa explícitamente varias familias de fallo para evitar diagn
 - `executor_auth`: credenciales inválidas o sin permiso para que el backend de agente procese requests;
 - `executor_config`: executor declarado pero mal configurado para el entorno actual;
 - `executor_missing`: binario o wrapper ausente;
+- `timeout`: el executor o una validación superó el tiempo máximo configurado y la sesión abortó o pasó a reintento;
 - `validation`: tests, quality, typing o docs-governance rojos;
 - `command_failure`: otros errores no clasificados todavía.
 

--- a/engine_config/policies/orchestrator_policy.json
+++ b/engine_config/policies/orchestrator_policy.json
@@ -4,7 +4,10 @@
     "planning": {"max_tasks": 5},
     "execution": {
         "max_attempts_per_task": 3,
-        "commit_mode": "single_commit_after_success"
+        "commit_mode": "single_commit_after_success",
+        "executor_timeout_seconds": 900,
+        "executor_preflight_timeout_seconds": 60,
+        "validation_timeout_seconds": 1800
     },
     "pull_request": {
         "base_branch": "main",

--- a/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
+++ b/src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import shlex
+import signal
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -135,18 +136,7 @@ def create_request_dir(policy: dict[str, Any], request_text: str) -> Path:
 def ensure_clean_worktree(*, allow_dirty: bool) -> None:
     if allow_dirty:
         return
-    result = subprocess.run(
-        ["git", "status", "--short"],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            result.stderr.strip() or "No se pudo inspeccionar git status."
-        )
-    if result.stdout.strip():
+    if git_status_has_relevant_changes():
         raise RuntimeError(
             "El worktree no está limpio. Usa --allow-dirty solo si entiendes el riesgo."
         )
@@ -256,6 +246,10 @@ def collect_changed_python_files() -> list[str]:
 
 
 def has_worktree_changes() -> bool:
+    return git_status_has_relevant_changes()
+
+
+def read_git_status_lines() -> list[str]:
     result = subprocess.run(
         ["git", "status", "--short"],
         cwd=ROOT,
@@ -267,7 +261,23 @@ def has_worktree_changes() -> bool:
         raise RuntimeError(
             result.stderr.strip() or "No se pudo inspeccionar el estado del worktree."
         )
-    return bool(result.stdout.strip())
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def is_ignorable_git_status_path(path: str) -> bool:
+    normalized = path.strip()
+    return "__pycache__/" in normalized or normalized.endswith((".pyc", ".pyo", ".pyd"))
+
+
+def git_status_has_relevant_changes() -> bool:
+    for line in read_git_status_lines():
+        path = line[3:]
+        if "->" in path:
+            path = path.split("->", maxsplit=1)[1].strip()
+        if is_ignorable_git_status_path(path):
+            continue
+        return True
+    return False
 
 
 def load_json_file(path: Path) -> dict[str, Any]:
@@ -319,36 +329,82 @@ def classify_command_failure(command: list[str], output: str) -> str:
 
 
 def build_command_failure_message(
-    category: str, command: list[str], output_path: Path
+    category: str,
+    command: list[str],
+    output_path: Path,
+    *,
+    timeout_seconds: int | None = None,
 ) -> str:
     prefix = {
         "executor_auth": "Fallo de autenticación del executor.",
         "executor_config": "Configuración inválida del executor.",
         "executor_missing": "El comando del executor no está disponible en este entorno.",
+        "timeout": "El comando del orquestador superó el tiempo máximo permitido.",
         "validation": "Falló una validación estándar del repo.",
         "command_failure": "Falló un comando del orquestador.",
     }.get(category, "Falló un comando del orquestador.")
+    timeout_suffix = (
+        f" Timeout: {timeout_seconds}s."
+        if category == "timeout" and timeout_seconds
+        else ""
+    )
     return (
         f"{prefix} Categoría: {category}. "
         f"Comando: {' '.join(command)}. "
-        f"Log: {output_path}"
+        f"Log: {output_path}."
+        f"{timeout_suffix}"
     )
 
 
-def run_command(command: list[str], *, output_path: Path) -> None:
+def run_command(
+    command: list[str],
+    *,
+    output_path: Path,
+    timeout_seconds: int | None = None,
+) -> None:
     env = build_runtime_env()
     env["PYTHONPATH"] = str(ROOT / "src")
-    result = subprocess.run(
+    env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+    process = subprocess.Popen(
         command,
         cwd=ROOT,
         env=env,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        check=False,
+        start_new_session=True,
     )
-    output = (result.stdout or "") + ("\n" + result.stderr if result.stderr else "")
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            process.kill()
+        stdout, stderr = process.communicate()
+        timeout_note = (
+            f"Command timed out after {timeout_seconds} seconds."
+            if timeout_seconds
+            else "Command timed out."
+        )
+        output = (stdout or "") + ("\n" + stderr if stderr else "")
+        output = f"{output}\n{timeout_note}".strip() + "\n"
+        output_path.write_text(output, encoding="utf-8")
+        raise OrchestratorCommandError(
+            build_command_failure_message(
+                "timeout",
+                command,
+                output_path,
+                timeout_seconds=timeout_seconds,
+            ),
+            category="timeout",
+            command=command,
+            output_path=output_path,
+            raw_output=output.strip(),
+        )
+    output = (stdout or "") + ("\n" + stderr if stderr else "")
     output_path.write_text(output, encoding="utf-8")
-    if result.returncode != 0:
+    if process.returncode != 0:
         category = classify_command_failure(command, output)
         raise OrchestratorCommandError(
             build_command_failure_message(category, command, output_path),
@@ -400,6 +456,8 @@ def validate_executor_configuration(command_template: str) -> None:
 
 
 def preflight_executor(request_dir: Path, command_template: str) -> None:
+    policy = load_orchestrator_policy()
+    timeouts = resolve_execution_timeouts(policy)
     validate_executor_configuration(command_template)
     if not executor_uses_github_wrapper(command_template):
         return
@@ -420,6 +478,7 @@ def preflight_executor(request_dir: Path, command_template: str) -> None:
                 attempt=0,
             ),
             output_path=output_path,
+            timeout_seconds=timeouts["executor_preflight_timeout_seconds"],
         )
     finally:
         if env_var:
@@ -430,6 +489,7 @@ def preflight_executor(request_dir: Path, command_template: str) -> None:
 
 def run_standard_validations(request_dir: Path) -> None:
     policy = load_orchestrator_policy()
+    timeouts = resolve_execution_timeouts(policy)
     python_bin = resolve_python_bin()
     validation_commands = [
         [python_bin if token == "python" else token for token in entry["command"]]
@@ -456,7 +516,24 @@ def run_standard_validations(request_dir: Path) -> None:
     validation_commands.extend([quality_command, typing_command])
 
     for index, command in enumerate(validation_commands, start=1):
-        run_command(command, output_path=request_dir / f"validation_{index}.log")
+        run_command(
+            command,
+            output_path=request_dir / f"validation_{index}.log",
+            timeout_seconds=timeouts["validation_timeout_seconds"],
+        )
+
+
+def resolve_execution_timeouts(policy: dict[str, Any]) -> dict[str, int]:
+    execution = policy.get("execution", {}) or {}
+    return {
+        "executor_timeout_seconds": int(execution.get("executor_timeout_seconds", 900)),
+        "executor_preflight_timeout_seconds": int(
+            execution.get("executor_preflight_timeout_seconds", 60)
+        ),
+        "validation_timeout_seconds": int(
+            execution.get("validation_timeout_seconds", 1800)
+        ),
+    }
 
 
 def create_commit(commit_title: str) -> None:
@@ -834,6 +911,7 @@ def repair_pull_request(
     round_number: int,
     additional_feedback: str | None = None,
 ) -> bool:
+    timeouts = resolve_execution_timeouts(load_orchestrator_policy())
     append_reconciliation_event(
         request_dir,
         {
@@ -864,6 +942,7 @@ def repair_pull_request(
         run_command(
             executor_args,
             output_path=request_dir / f"pr_reconciliation_{round_number}.log",
+            timeout_seconds=timeouts["executor_timeout_seconds"],
         )
     except OrchestratorCommandError as exc:
         append_reconciliation_event(
@@ -1181,6 +1260,7 @@ def execute_plan(
     skip_auto_merge: bool,
 ) -> None:
     policy = load_orchestrator_policy()
+    timeouts = resolve_execution_timeouts(policy)
     max_attempts = int(policy.get("execution", {}).get("max_attempts_per_task", 3))
     preflight_executor(request_dir, executor_command)
 
@@ -1204,6 +1284,7 @@ def execute_plan(
                 run_command(
                     executor_args,
                     output_path=request_dir / f"{task['id']}_executor_{attempt}.log",
+                    timeout_seconds=timeouts["executor_timeout_seconds"],
                 )
                 run_standard_validations(request_dir)
                 break

--- a/tests/test_run_product_owner_orchestrator.py
+++ b/tests/test_run_product_owner_orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,29 @@ def test_resolve_resume_selector_prefers_branch() -> None:
     args = orchestrator.parse_args(["resume-pr", "--branch", "feat/test"])
 
     assert orchestrator.resolve_resume_selector(args) == "feat/test"
+
+
+def test_git_status_has_relevant_changes_ignores_python_cache(monkeypatch) -> None:
+    monkeypatch.setattr(
+        orchestrator,
+        "read_git_status_lines",
+        lambda: ["?? src/assessment_engine/scripts/lib/__pycache__/"],
+    )
+
+    assert orchestrator.git_status_has_relevant_changes() is False
+
+
+def test_git_status_has_relevant_changes_keeps_real_files(monkeypatch) -> None:
+    monkeypatch.setattr(
+        orchestrator,
+        "read_git_status_lines",
+        lambda: [
+            "?? src/assessment_engine/scripts/lib/__pycache__/",
+            " M docs/README.md",
+        ],
+    )
+
+    assert orchestrator.git_status_has_relevant_changes() is True
 
 
 def test_create_pr_body_includes_spec_and_tasks() -> None:
@@ -311,7 +335,9 @@ def test_repair_pull_request_allows_noop_when_validations_pass(
     monkeypatch.setattr(
         orchestrator,
         "run_command",
-        lambda command, *, output_path: outputs.append(str(output_path)),
+        lambda command, *, output_path, timeout_seconds=None: outputs.append(
+            str(output_path)
+        ),
     )
     monkeypatch.setattr(orchestrator, "has_worktree_changes", lambda: False)
     monkeypatch.setattr(
@@ -373,14 +399,17 @@ def test_preflight_executor_runs_wrapper_probe(monkeypatch, tmp_path: Path) -> N
     request_dir = tmp_path / "request"
     request_dir.mkdir()
     monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
-    calls: list[tuple[list[str], Path, str | None]] = []
+    calls: list[tuple[list[str], Path, str | None, int | None]] = []
 
-    def fake_run_command(command: list[str], *, output_path: Path) -> None:
+    def fake_run_command(
+        command: list[str], *, output_path: Path, timeout_seconds: int | None = None
+    ) -> None:
         calls.append(
             (
                 command,
                 output_path,
                 os.environ.get("ORCHESTRATOR_EXECUTOR_PREFLIGHT"),
+                timeout_seconds,
             )
         )
 
@@ -394,11 +423,54 @@ def test_preflight_executor_runs_wrapper_probe(monkeypatch, tmp_path: Path) -> N
     assert calls
     assert calls[0][2] == "1"
     assert calls[0][1].name == "executor_preflight.log"
+    assert calls[0][3] == 60
     assert (
         (request_dir / "executor_preflight_prompt.md")
         .read_text(encoding="utf-8")
         .startswith("Executor preflight.")
     )
+
+
+def test_run_command_times_out_and_classifies_timeout(
+    monkeypatch, tmp_path: Path
+) -> None:
+    class FakeProcess:
+        def __init__(self):
+            self.pid = 4242
+            self.returncode = None
+            self._timed_out = False
+
+        def communicate(self, timeout=None):
+            if not self._timed_out:
+                self._timed_out = True
+                raise subprocess.TimeoutExpired(cmd=["executor"], timeout=timeout)
+            self.returncode = -9
+            return ("partial stdout", "partial stderr")
+
+    output_path = tmp_path / "timeout.log"
+    killed: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(orchestrator, "build_runtime_env", lambda: {})
+    monkeypatch.setattr(
+        orchestrator.subprocess, "Popen", lambda *args, **kwargs: FakeProcess()
+    )
+    monkeypatch.setattr(
+        orchestrator.os, "killpg", lambda pid, sig: killed.append((pid, sig))
+    )
+
+    with pytest.raises(
+        orchestrator.OrchestratorCommandError, match="Categoría: timeout"
+    ):
+        orchestrator.run_command(
+            ["executor", "--task"],
+            output_path=output_path,
+            timeout_seconds=5,
+        )
+
+    assert killed == [(4242, orchestrator.signal.SIGKILL)]
+    output = output_path.read_text(encoding="utf-8")
+    assert "Command timed out after 5 seconds." in output
+    assert "partial stdout" in output
 
 
 def test_reconcile_pull_request_auto_resolves_bot_threads(


### PR DESCRIPTION
## Summary
- add explicit executor/preflight/validation timeouts to the product owner orchestrator so hung executor runs fail instead of blocking forever
- ignore Python cache artifacts in worktree cleanliness checks and export `PYTHONDONTWRITEBYTECODE=1` from `./bin/po-run`
- document the new operational behavior and cover it with orchestrator tests

## Testing
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python -m pytest tests/test_run_product_owner_orchestrator.py tests/test_po_run_wrapper.py -q`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_quality_gate.py --repo-root . --path src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py --path tests/test_run_product_owner_orchestrator.py --path bin/po-run`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/run_incremental_typecheck.py --repo-root . --path src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py --path tests/test_run_product_owner_orchestrator.py`
- `PYTHONPATH=src /home/jsanchhi/.venv/bin/python src/assessment_engine/scripts/tools/validate_documentation_governance.py --repo-root . --documentation-map docs/documentation-map.yaml --base-sha origin/main --head-sha HEAD`