### PR TITLE
Fix: Change Command Palette shortcut to Ctrl+J

### DIFF
--- a/src/business_command_center/src/app/components/CommandPalette.tsx
+++ b/src/business_command_center/src/app/components/CommandPalette.tsx
@@ -17,7 +17,7 @@ export default function CommandPalette() {
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      if (e.key === 'j' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         setOpen((open) => !open);
       }


### PR DESCRIPTION
Ctrl+K conflicts with browser search bars (Chrome/Edge/Firefox) on Windows. Changed to Ctrl+J for better cross-platform support.