### PR TITLE
Harden documentation governance

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -32,4 +32,6 @@ jobs:
         run: |
           python src/assessment_engine/scripts/tools/validate_documentation_governance.py \
             --repo-root . \
-            --documentation-map docs/documentation-map.yaml
+            --documentation-map docs/documentation-map.yaml \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,9 @@ Si un documento narrativo contradice al código o a los contratos, **manda el re
 | [`operations/engineering-quality-gates.md`](operations/engineering-quality-gates.md) | Política canónica de calidad de implementación |
 | [`operations/product-owner-orchestrator.md`](operations/product-owner-orchestrator.md) | Orquestador local desde petición de negocio hasta PR |
 | [`../bin/po-run`](../bin/po-run) | Wrapper friendly para lanzar el orquestador local desde terminal |
-| [`../.github/workflows/orchestrator-pr-reconcile.yml`](../.github/workflows/orchestrator-pr-reconcile.yml) | Watcher automático que reanuda PRs gestionadas del orquestador |
-| [`../.github/scripts/orchestrator-gemini-executor.sh`](../.github/scripts/orchestrator-gemini-executor.sh) | Wrapper de executor para usar Gemini CLI dentro de GitHub Actions |
+| [`../.github/workflows/orchestrator-pr-reconcile.yml`](../.github/workflows/orchestrator-pr-reconcile.yml) | Reconciliador de ramas de PR abiertas tras cambios en `main`; no es un executor de agentes |
+| [`../.github/scripts/reconcile_prs.sh`](../.github/scripts/reconcile_prs.sh) | Script usado por el reconciliador para rebasear ramas de PR contra `origin/main` |
+| [`../.github/scripts/orchestrator-gemini-executor.sh`](../.github/scripts/orchestrator-gemini-executor.sh) | Wrapper local de executor Gemini; no está cableado por el reconciliador actual de GitHub |
 | [`contracts/`](contracts/artifact-contracts.md) | Contratos, matrices y plantillas de diseño |
 | [`reference/generated/`](reference/generated/legacy-gemini-index.md) | Referencia derivada o heredada no canónica |
 | [`../GEMINI.md`](../GEMINI.md) | Adaptador para Gemini y memoria operativa en transición |
@@ -113,7 +114,8 @@ Si una sesión nueva necesita reanudar el trabajo sin contexto previo, el estado
 - ya existe un MVP de orquestador local PO-to-PR apoyado en backend de agente configurable;
 - ya existe `./bin/po-run` como entrada corta e interactiva para lanzar ese flujo desde terminal;
 - el orquestador local ya acota los `run` del executor con timeout explícito y evita que la propia ejecución ensucie el worktree con `__pycache__/`;
-- ya existe un watcher de GitHub que puede reanudar PRs gestionadas del orquestador cuando fallan checks o aparece feedback nuevo;
-- ya existe un executor del repo compatible con GitHub Actions para que el watcher no dependa de rutas locales;
+- ya existe un reconciliador de GitHub que, tras cambios en `main` o por ejecución manual, intenta rebasear ramas de PR abiertas no draft que no tengan la label `no-auto-update`;
+- no existe todavía un watcher de GitHub que reanude automáticamente `resume-pr` ante feedback, reviews o checks fallidos;
+- existe un wrapper de executor Gemini en el repo, pero no está conectado al reconciliador de PR actual;
 - el baseline smoke de `smoke_ivirma` ya está cerrado para T5, global, comercial y web;
 - la suite completa de `pytest` pasa.

--- a/docs/architecture/apex_maturity_model_roadmap.md
+++ b/docs/architecture/apex_maturity_model_roadmap.md
@@ -1,3 +1,16 @@
+---
+status: Needs Review
+owner: docs-governance
+source_of_truth:
+  - docs/SYSTEM_ARCHITECTURE.md
+  - src/assessment_engine/
+last_verified_against: 2026-06-25
+applies_to:
+  - humans
+  - ai-agents
+doc_type: canonical
+---
+
 # Apex Enterprise Roadmap: Hacia la Madurez Nivel 4 (CNCF)
 
 Este documento define la estrategia de evolución de **The Apex** desde un orquestador de IA funcional hacia una **Plataforma de IA Autónoma de Grado Enterprise**. El objetivo es alcanzar el "100% perfecto" en seguridad, observabilidad, eficiencia financiera (FinOps) y gobernanza.

--- a/docs/architecture/elite-governance-2026.md
+++ b/docs/architecture/elite-governance-2026.md
@@ -19,7 +19,7 @@ source_of_truth:
 
 Este documento define la arquitectura "The Apex", una capa de gobernanza y supervisión diseñada para garantizar la máxima calidad, fiabilidad y cumplimiento normativo de los artefactos generados por el `assessment-engine`. The Apex se compone de tres agentes especializados que operan en concierto para formar un sistema inmunitario digital que protege la integridad del pipeline.
 
-Esta arquitectura es la implementación de referencia para la operación en **Modo de Gobernanza**, como se describe en el [documento de arquitectura del sistema](./SYSTEM_ARCHITECTURE.md).
+Esta arquitectura es la implementación de referencia para la operación en **Modo de Gobernanza**, como se describe en el [documento de arquitectura del sistema](../SYSTEM_ARCHITECTURE.md).
 
 ## 2. Principios de Diseño
 

--- a/docs/audits/AUDIT_FRAMEWORK.md
+++ b/docs/audits/AUDIT_FRAMEWORK.md
@@ -1,3 +1,15 @@
+---
+status: Needs Review
+owner: docs-governance
+source_of_truth:
+  - docs/
+  - src/assessment_engine/
+last_verified_against: 2026-06-25
+applies_to:
+  - humans
+doc_type: operational
+---
+
 # Framework de Auditoría de Documentación
 
 ## 1. Introducción

--- a/docs/audits/AUDIT_RESULTS.md
+++ b/docs/audits/AUDIT_RESULTS.md
@@ -1,3 +1,15 @@
+---
+status: Needs Review
+owner: docs-governance
+source_of_truth:
+  - docs/
+  - src/assessment_engine/
+last_verified_against: 2026-06-25
+applies_to:
+  - humans
+doc_type: operational
+---
+
 # Auditoría de Documentación y Código - Resultados
 
 ## 1. Introducción
@@ -121,4 +133,3 @@ A continuación se detallan los hallazgos de cada módulo de código auditado.
 *   **Hallazgos:**
     *   **(Claridad)**: El código es claro, bien estructurado y sigue el principio de responsabilidad única.
     *   **(Docstrings)**: Faltan docstrings en las funciones. Aunque los nombres de las funciones son descriptivos, las docstrings ayudarían a entender qué tipo de configuración carga cada una sin necesidad de leer el código.
-

--- a/docs/audits/GOVERNANCE_IMPROVEMENT_PROPOSAL.md
+++ b/docs/audits/GOVERNANCE_IMPROVEMENT_PROPOSAL.md
@@ -1,3 +1,16 @@
+---
+status: Needs Review
+owner: docs-governance
+source_of_truth:
+  - docs/ai/documentation-governance.md
+  - docs/documentation-map.yaml
+last_verified_against: 2026-06-25
+applies_to:
+  - humans
+  - ai-agents
+doc_type: operational
+---
+
 # Propuesta de Mejora de la Gobernanza de la Documentación
 
 ## 1. Introducción

--- a/docs/audits/IMPROVEMENT_BACKLOG.md
+++ b/docs/audits/IMPROVEMENT_BACKLOG.md
@@ -1,3 +1,15 @@
+---
+status: Needs Review
+owner: docs-governance
+source_of_truth:
+  - docs/
+  - src/assessment_engine/
+last_verified_against: 2026-06-25
+applies_to:
+  - humans
+doc_type: operational
+---
+
 # Backlog de Mejoras de Documentación y Código
 
 ## 1. Introducción

--- a/docs/documentation-map.yaml
+++ b/docs/documentation-map.yaml
@@ -237,9 +237,9 @@ entries:
 
   - path: .github/workflows/orchestrator-pr-reconcile.yml
     kind: document
-    title: Orchestrator PR reconciliation watcher
+    title: Open PR branch reconciler
     doc_type: operational
-    status: Verified
+    status: Needs Review
     owner: docs-governance
     applies_to:
       - humans
@@ -247,25 +247,24 @@ entries:
     source_of_truth:
       - docs/operations/product-owner-orchestrator.md
       - docs/operations/engineering-quality-gates.md
-      - .github/scripts/orchestrator-gemini-executor.sh
-      - src/assessment_engine/scripts/tools/run_product_owner_orchestrator.py
-    last_verified_against: 2026-05-01
-    notes: Workflow que reanuda automáticamente PRs gestionadas por el orquestador cuando llegan checks, comentarios o ejecuciones manuales.
+      - .github/scripts/reconcile_prs.sh
+    last_verified_against: 2026-06-25
+    notes: Workflow que rebasea ramas de PR abiertas no draft contra main tras cambios en main o ejecución manual; no reanuda resume-pr ni ejecuta agentes.
 
   - path: .github/scripts/orchestrator-gemini-executor.sh
     kind: document
-    title: GitHub Actions executor wrapper for the product owner orchestrator
+    title: Local Gemini executor wrapper for the product owner orchestrator
     doc_type: operational
-    status: Verified
+    status: Needs Review
     owner: docs-governance
     applies_to:
       - humans
       - ai-agents
     source_of_truth:
       - docs/operations/product-owner-orchestrator.md
-      - .github/workflows/orchestrator-pr-reconcile.yml
-    last_verified_against: 2026-05-01
-    notes: Wrapper del repo que autentica Copilot CLI en GitHub Actions y ejecuta el prompt de reconciliación contra la rama activa.
+      - .github/scripts/orchestrator-gemini-executor.sh
+    last_verified_against: 2026-06-25
+    notes: Wrapper de executor Gemini disponible en el repo; no está cableado por el reconciliador actual de PRs.
 
   - path: bin/po-run
     kind: document
@@ -1152,6 +1151,21 @@ entries:
       - src/assessment_engine/
     last_verified_against: 2026-04-30
     notes: Colección archivada en la capa neutral de referencia; puede consultarse, pero ya no debe competir con la documentación canónica.
+
+  - path: docs/audits
+    kind: collection
+    title: Documentation and code audits
+    doc_type: operational
+    status: Needs Review
+    owner: docs-governance
+    applies_to:
+      - humans
+      - ai-agents
+    source_of_truth:
+      - docs/
+      - src/assessment_engine/
+    last_verified_against: 2026-06-25
+    notes: Material de auditoría y backlog; útil para seguimiento, pero no debe leerse como verdad actual sin reverificación.
 
   - path: docs/documentation_audit.md
     kind: document

--- a/docs/operations/product-owner-orchestrator.md
+++ b/docs/operations/product-owner-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-status: Verified
+status: Needs Review
 owner: docs-governance
 source_of_truth:
   - ../../bin/po-run
@@ -11,7 +11,9 @@ source_of_truth:
   - ../../.github/workflows/ci.yml
   - ../../.github/workflows/quality.yml
   - ../../.github/workflows/typing.yml
-last_verified_against: 2026-05-02
+  - ../../.github/workflows/orchestrator-pr-reconcile.yml
+  - ../../.github/scripts/reconcile_prs.sh
+last_verified_against: 2026-06-25
 applies_to:
   - humans
   - ai-agents
@@ -152,26 +154,41 @@ Por defecto puede resolver automáticamente **threads abiertos creados por bots*
 
 La sincronización con la base ocurre dentro del mismo circuito controlado: el orquestador trae `origin/<base_branch>` a la rama activa, vuelve a ejecutar las validaciones locales y solo hace push si la rama sigue pasando los gates. Si esa sincronización introduce un fallo, ese fallo entra como feedback de la siguiente ronda de reparación; no se salta.
 
-### 6. Watcher automático en GitHub
+### 6. Reconciliador actual de PRs en GitHub
 
-El repo puede ejecutar `.github/workflows/orchestrator-pr-reconcile.yml` para relanzar `resume-pr` cuando una PR gestionada:
+El workflow `.github/workflows/orchestrator-pr-reconcile.yml` existe, pero su comportamiento actual es más limitado que una reanudación agentic de `resume-pr`.
 
-1. recibe feedback de review o comentarios;
-2. sale de draft con `ready_for_review`;
-3. o se relanza manualmente con `workflow_dispatch`.
+Estado verificado contra `.github/workflows/orchestrator-pr-reconcile.yml` y `.github/scripts/reconcile_prs.sh`:
 
-Reglas de seguridad del watcher:
+- se ejecuta tras `push` a `main` o manualmente con `workflow_dispatch`;
+- lista PRs abiertas, no draft, que no tengan la label `no-auto-update`;
+- resetea el checkout local a `origin/main`;
+- rebasea cada rama de PR sobre `origin/main`;
+- comenta en la PR si el rebase tiene conflictos;
+- hace `push --force-with-lease` cuando el rebase termina correctamente.
 
-- solo actúa sobre PRs **abiertas**, **no draft**, del **mismo repositorio**;
-- exige que la PR tenga el marcador oculto del orquestador o la label `orchestrator-managed`;
-- serializa la ejecución por número de PR para no correr dos reconciliaciones en paralelo;
-- no se relanza por cada workflow verde intermedio: el run abierto por `pull_request` mantiene el polling de checks hasta que la PR queda lista para merge o necesita reparación;
-- reutiliza `resume-pr`, así que sigue pasando por tests, quality, typing, docs-governance, sync con `main` y reglas de review;
-- usa por defecto `./.github/scripts/orchestrator-gemini-executor.sh {repo_root} {task_prompt_file} {attempt}` como executor compatible con GitHub Actions;
-- la regla operativa recomendada es mantener `ASSESSMENT_ORCHESTRATOR_EXECUTOR_CMD` configurado en GitHub Actions apuntando a ese wrapper del repo, para no depender de rutas locales o wrappers efímeros;
-- el wrapper del repo ejecuta `gemini-2.5-pro` por defecto y fuerza la ruta Gemini de forma coherente con el resto de scripts;
-- para que el executor pueda autenticarse de forma estable en GitHub Actions, el repo debe exponer una credencial Gemini o Google válida: `GEMINI_API_KEY`, `GOOGLE_API_KEY` o autenticación Google/Vertex habilitada con `GOOGLE_GENAI_USE_VERTEXAI=1` y credenciales de aplicación disponibles en el runner;
-- si el preflight del executor falla por credenciales o configuración, la reconciliación aborta antes de entrar en rondas largas de reparación y deja el motivo clasificado en los artefactos de sesión.
+Límites explícitos del reconciliador actual:
+
+- no llama a `run_product_owner_orchestrator.py resume-pr`;
+- no inspecciona threads de review ni feedback humano;
+- no filtra por marcador oculto `<!-- orchestrator-managed -->`;
+- no exige label `orchestrator-managed`;
+- no ejecuta el wrapper `orchestrator-gemini-executor.sh`;
+- no repara checks fallidos con un backend de agente;
+- no ejecuta los gates locales después del rebase dentro de ese workflow.
+
+Por tanto, este workflow debe leerse como **actualizador de ramas de PR**, no como watcher agentic end-to-end.
+
+### 7. Watcher agentic objetivo
+
+La automatización descrita abajo sigue siendo un objetivo de endurecimiento, no una capacidad verificada del workflow actual:
+
+1. relanzar `resume-pr` cuando una PR gestionada reciba feedback, salga de draft o tenga checks fallidos;
+2. exigir marcador oculto del orquestador o label `orchestrator-managed`;
+3. serializar ejecución por número de PR;
+4. ejecutar validación estándar después de cada reparación;
+5. usar un executor configurado explícitamente para GitHub Actions;
+6. fallar temprano si las credenciales del executor no están disponibles.
 
 ## Política configurable
 
@@ -183,7 +200,8 @@ Reglas de seguridad del watcher:
 - rama base;
 - modo de auto-merge;
 - reconciliación post-PR (polling, rondas máximas, sync con base y resolución automática de threads de bot);
-- watcher automático de reanudación para PRs gestionadas;
+- reconciliación post-PR del orquestador local;
+- reconciliador de ramas de PR abiertas en GitHub;
 - timeouts del executor, del preflight y de las validaciones;
 - validaciones estándar.
 
@@ -202,11 +220,12 @@ La intención no es maquillar el error sino **fallar antes y con una causa accio
 
 ## Pendiente para cierre end-to-end
 
-El flujo ya puede operar de forma homogénea sobre Gemini también en la reconciliación automática de PRs, pero para considerar el circuito **realmente cerrado de punta a punta en GitHub Actions** sigue pendiente habilitar la credencial del executor en el repo:
+El flujo local puede operar con un executor configurable, pero para considerar el circuito **realmente cerrado de punta a punta en GitHub Actions** sigue pendiente implementar y verificar un watcher agentic que invoque `resume-pr`:
 
 1. configurar en GitHub Actions una credencial válida para Gemini o Google;
 2. decidir si el watcher usará `GEMINI_API_KEY`, `GOOGLE_API_KEY` o autenticación Google/Vertex del runner;
-3. verificar con una PR gestionada real que `resume-pr` completa preflight, reparación, validación y merge sin intervención manual.
+3. conectar `.github/workflows/orchestrator-pr-reconcile.yml` o un nuevo workflow a `resume-pr`;
+4. verificar con una PR gestionada real que `resume-pr` completa preflight, reparación, validación y merge sin intervención manual.
 
 ## Limitaciones deliberadas del MVP
 

--- a/src/assessment_engine/scripts/tools/validate_documentation_governance.py
+++ b/src/assessment_engine/scripts/tools/validate_documentation_governance.py
@@ -7,7 +7,7 @@ import subprocess
 from datetime import date, datetime
 from pathlib import Path
 
-import yaml  # type: ignore
+import yaml  # type: ignore[import-untyped]
 
 VALID_STATUSES = {"Verified", "Needs Review", "Draft", "Deprecated"}
 VALID_DOC_TYPES = {"canonical", "operational", "reference_generated", "archived"}
@@ -21,6 +21,9 @@ FRONT_MATTER_REQUIRED = {
     "doc_type",
 }
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+DEFAULT_COVERAGE_INCLUDE = ["README.md", "AGENTS.md", "CHATGPT.md", "docs/**/*.md"]
+DEFAULT_COVERAGE_EXCLUDE = ["docs/reference/generated/legacy-gemini/**"]
 
 
 def load_yaml(path: Path) -> dict:
@@ -60,8 +63,137 @@ def is_subpath(changed_path: str, required_path: str) -> bool:
     return changed_path.startswith(required_path.rstrip("/") + "/")
 
 
+def normalize_repo_path(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def should_validate_markdown_target(target: str) -> bool:
+    stripped = target.strip()
+    if not stripped or stripped.startswith("#"):
+        return False
+    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", stripped):
+        return False
+    return True
+
+
+def markdown_link_target_path(current_path: Path, target: str) -> Path | None:
+    if not should_validate_markdown_target(target):
+        return None
+
+    local_target = target.split("#", 1)[0].split("?", 1)[0]
+    if not local_target:
+        return None
+    return (current_path.parent / local_target).resolve()
+
+
+def validate_markdown_links(current_path: Path, entry_path: str, errors: list[str]) -> None:
+    text = current_path.read_text(encoding="utf-8")
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target_path = markdown_link_target_path(current_path, match.group(1))
+        if target_path is None:
+            continue
+        if not target_path.exists():
+            errors.append(
+                f"{entry_path}: markdown link target does not exist: {match.group(1)}"
+            )
+
+
+def is_path_covered_by_entry(path: str, entry_path: str, kind: str) -> bool:
+    if kind == "document":
+        return path == entry_path
+    if kind == "collection":
+        return is_subpath(path, entry_path)
+    return False
+
+
 def matches_any_pattern(path: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def validate_front_matter_fields(
+    front_matter: dict, entry_path: str, error_prefix: str, errors: list[str]
+) -> None:
+    missing_front_matter = sorted(FRONT_MATTER_REQUIRED - set(front_matter))
+    if missing_front_matter:
+        errors.append(
+            f"{entry_path}: {error_prefix} missing fields: "
+            + ", ".join(missing_front_matter)
+        )
+        return
+
+    if front_matter.get("status") not in VALID_STATUSES:
+        errors.append(f"{entry_path}: {error_prefix} has invalid status")
+    if front_matter.get("doc_type") not in VALID_DOC_TYPES:
+        errors.append(f"{entry_path}: {error_prefix} has invalid doc_type")
+    if not isinstance(
+        front_matter.get("source_of_truth"), list
+    ) or not front_matter.get("source_of_truth"):
+        errors.append(
+            f"{entry_path}: {error_prefix} source_of_truth must be a non-empty list"
+        )
+    if not isinstance(front_matter.get("applies_to"), list) or not front_matter.get(
+        "applies_to"
+    ):
+        errors.append(
+            f"{entry_path}: {error_prefix} applies_to must be a non-empty list"
+        )
+    if not is_valid_date_value(front_matter.get("last_verified_against", "")):
+        errors.append(
+            f"{entry_path}: {error_prefix} last_verified_against must use YYYY-MM-DD"
+        )
+
+
+def validate_documentation_coverage(
+    repo_root: Path, documentation_map: dict, entries: list[dict], errors: list[str]
+) -> None:
+    coverage = documentation_map.get("coverage", {})
+    include_patterns = coverage.get("include", DEFAULT_COVERAGE_INCLUDE)
+    exclude_patterns = coverage.get("exclude", DEFAULT_COVERAGE_EXCLUDE)
+
+    if not isinstance(include_patterns, list) or not include_patterns:
+        errors.append("documentation-map.yaml coverage.include must be a non-empty list")
+        return
+    if not isinstance(exclude_patterns, list):
+        errors.append("documentation-map.yaml coverage.exclude must be a list")
+        return
+
+    governed_paths: set[str] = set()
+    for pattern in include_patterns:
+        if not isinstance(pattern, str) or not pattern:
+            errors.append("documentation-map.yaml coverage.include entries must be strings")
+            continue
+        for discovered_path in repo_root.glob(pattern):
+            if discovered_path.is_file():
+                governed_paths.add(normalize_repo_path(discovered_path, repo_root))
+
+    for governed_path in sorted(governed_paths):
+        if matches_any_pattern(governed_path, exclude_patterns):
+            continue
+
+        if not any(
+            is_path_covered_by_entry(governed_path, entry["path"], entry["kind"])
+            for entry in entries
+            if isinstance(entry.get("path"), str)
+            and isinstance(entry.get("kind"), str)
+        ):
+            errors.append(
+                f"{governed_path}: markdown document is not covered by documentation-map"
+            )
+            continue
+
+        absolute_path = repo_root / governed_path
+        front_matter = read_front_matter(absolute_path)
+        if front_matter is None:
+            errors.append(
+                f"{governed_path}: covered markdown document is missing YAML front matter"
+            )
+            continue
+
+        validate_front_matter_fields(
+            front_matter, governed_path, "covered markdown front matter", errors
+        )
+        if front_matter.get("doc_type") in {"canonical", "operational"}:
+            validate_markdown_links(absolute_path, governed_path, errors)
 
 
 def validate_path_list_field(
@@ -203,33 +335,9 @@ def validate_entry(repo_root: Path, entry: dict, errors: list[str]) -> None:
             )
             return
 
-        missing_front_matter = sorted(FRONT_MATTER_REQUIRED - set(front_matter))
-        if missing_front_matter:
-            errors.append(
-                f"{entry_path}: front matter missing fields: {', '.join(missing_front_matter)}"
-            )
-            return
-
-        if front_matter.get("status") not in VALID_STATUSES:
-            errors.append(f"{entry_path}: front matter has invalid status")
-        if front_matter.get("doc_type") not in VALID_DOC_TYPES:
-            errors.append(f"{entry_path}: front matter has invalid doc_type")
-        if not isinstance(
-            front_matter.get("source_of_truth"), list
-        ) or not front_matter.get("source_of_truth"):
-            errors.append(
-                f"{entry_path}: front matter source_of_truth must be a non-empty list"
-            )
-        if not isinstance(front_matter.get("applies_to"), list) or not front_matter.get(
-            "applies_to"
-        ):
-            errors.append(
-                f"{entry_path}: front matter applies_to must be a non-empty list"
-            )
-        if not is_valid_date_value(front_matter.get("last_verified_against", "")):
-            errors.append(
-                f"{entry_path}: front matter last_verified_against must use YYYY-MM-DD"
-            )
+        validate_front_matter_fields(front_matter, entry_path, "front matter", errors)
+        if doc_type in {"canonical", "operational"}:
+            validate_markdown_links(absolute_path, entry_path, errors)
 
 
 def validate_automation_rules(
@@ -364,6 +472,7 @@ def validate_documentation_governance(
         errors.append("documentation-map.yaml must define owners")
 
     seen_paths: set[str] = set()
+    valid_entries: list[dict] = []
     for entry in documentation_map["entries"]:
         if not isinstance(entry, dict):
             errors.append("documentation-map.yaml contains a non-object entry")
@@ -372,8 +481,14 @@ def validate_documentation_governance(
         if entry_path in seen_paths:
             errors.append(f"Duplicate documentation-map entry for path: {entry_path}")
             continue
-        seen_paths.add(entry_path)  # type: ignore
+        if not isinstance(entry_path, str):
+            errors.append("documentation-map entry path must be a string")
+            continue
+        seen_paths.add(entry_path)
         validate_entry(repo_root, entry, errors)
+        valid_entries.append(entry)
+
+    validate_documentation_coverage(repo_root, documentation_map, valid_entries, errors)
 
     changed_files = git_changed_files(repo_root, base_sha, head_sha)
     validate_automation_rules(

--- a/src/assessment_engine/scripts/tools/validate_documentation_governance.py
+++ b/src/assessment_engine/scripts/tools/validate_documentation_governance.py
@@ -86,7 +86,9 @@ def markdown_link_target_path(current_path: Path, target: str) -> Path | None:
     return (current_path.parent / local_target).resolve()
 
 
-def validate_markdown_links(current_path: Path, entry_path: str, errors: list[str]) -> None:
+def validate_markdown_links(
+    current_path: Path, entry_path: str, errors: list[str]
+) -> None:
     text = current_path.read_text(encoding="utf-8")
     for match in MARKDOWN_LINK_RE.finditer(text):
         target_path = markdown_link_target_path(current_path, match.group(1))
@@ -151,7 +153,9 @@ def validate_documentation_coverage(
     exclude_patterns = coverage.get("exclude", DEFAULT_COVERAGE_EXCLUDE)
 
     if not isinstance(include_patterns, list) or not include_patterns:
-        errors.append("documentation-map.yaml coverage.include must be a non-empty list")
+        errors.append(
+            "documentation-map.yaml coverage.include must be a non-empty list"
+        )
         return
     if not isinstance(exclude_patterns, list):
         errors.append("documentation-map.yaml coverage.exclude must be a list")
@@ -160,7 +164,9 @@ def validate_documentation_coverage(
     governed_paths: set[str] = set()
     for pattern in include_patterns:
         if not isinstance(pattern, str) or not pattern:
-            errors.append("documentation-map.yaml coverage.include entries must be strings")
+            errors.append(
+                "documentation-map.yaml coverage.include entries must be strings"
+            )
             continue
         for discovered_path in repo_root.glob(pattern):
             if discovered_path.is_file():
@@ -173,8 +179,7 @@ def validate_documentation_coverage(
         if not any(
             is_path_covered_by_entry(governed_path, entry["path"], entry["kind"])
             for entry in entries
-            if isinstance(entry.get("path"), str)
-            and isinstance(entry.get("kind"), str)
+            if isinstance(entry.get("path"), str) and isinstance(entry.get("kind"), str)
         ):
             errors.append(
                 f"{governed_path}: markdown document is not covered by documentation-map"

--- a/tests/test_validate_documentation_governance.py
+++ b/tests/test_validate_documentation_governance.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml  # type: ignore
+import yaml  # type: ignore[import-untyped]
 
 from assessment_engine.scripts.tools import (
     validate_documentation_governance as validator,
 )
 
 
-def _write_markdown(path: Path, title: str = "Doc") -> None:
+def _write_markdown(path: Path, title: str = "Doc", body: str = "") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         "\n".join(
@@ -28,6 +28,7 @@ def _write_markdown(path: Path, title: str = "Doc") -> None:
                 "",
                 f"# {title}",
                 "",
+                body,
             ]
         ),
         encoding="utf-8",
@@ -182,3 +183,69 @@ def test_source_linked_review_configuration_must_reference_real_paths(
     assert errors == [
         "docs/example.md: review_when_source_changes path does not exist: src/missing.py"
     ]
+
+
+def test_markdown_link_targets_must_exist(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "src").mkdir()
+    (repo_root / "src/example.py").write_text("print('hello')\n", encoding="utf-8")
+    _write_markdown(repo_root / "docs/example.md", body="[missing](missing.md)")
+
+    doc_map = repo_root / "docs/documentation-map.yaml"
+    doc_map.parent.mkdir(parents=True, exist_ok=True)
+    _write_map(
+        doc_map,
+        [
+            {
+                "path": "docs/example.md",
+                "kind": "document",
+                "title": "Example doc",
+                "doc_type": "canonical",
+                "status": "Verified",
+                "owner": "docs-governance",
+                "applies_to": ["humans", "ai-agents"],
+                "source_of_truth": ["src/example.py"],
+                "last_verified_against": "2026-04-30",
+                "notes": "Example",
+            }
+        ],
+    )
+
+    errors = validator.validate_documentation_governance(repo_root, doc_map, None, None)
+
+    assert any("markdown link target does not exist: missing.md" in e for e in errors)
+
+
+def test_markdown_coverage_requires_map_entry_or_collection(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "src").mkdir()
+    (repo_root / "src/example.py").write_text("print('hello')\n", encoding="utf-8")
+    _write_markdown(repo_root / "docs/example.md")
+    _write_markdown(repo_root / "docs/unmapped.md")
+
+    doc_map = repo_root / "docs/documentation-map.yaml"
+    doc_map.parent.mkdir(parents=True, exist_ok=True)
+    _write_map(
+        doc_map,
+        [
+            {
+                "path": "docs/example.md",
+                "kind": "document",
+                "title": "Example doc",
+                "doc_type": "canonical",
+                "status": "Verified",
+                "owner": "docs-governance",
+                "applies_to": ["humans", "ai-agents"],
+                "source_of_truth": ["src/example.py"],
+                "last_verified_against": "2026-04-30",
+                "notes": "Example",
+            }
+        ],
+    )
+
+    errors = validator.validate_documentation_governance(repo_root, doc_map, None, None)
+
+    assert any(
+        "docs/unmapped.md: markdown document is not covered by documentation-map" in e
+        for e in errors
+    )


### PR DESCRIPTION
## Summary
- harden documentation governance with Markdown coverage and local link checks
- align product-owner reconciler docs with the current GitHub workflow behavior
- add missing front matter for audit/roadmap docs as Needs Review

## Validation
- ./.venv/bin/python src/assessment_engine/scripts/tools/validate_documentation_governance.py --repo-root . --documentation-map docs/documentation-map.yaml
- ./.venv/bin/python -m pytest tests/test_validate_documentation_governance.py -q
- ./.venv/bin/python -m ruff check src/assessment_engine/scripts/tools/validate_documentation_governance.py tests/test_validate_documentation_governance.py
- ./.venv/bin/python -m mypy src/assessment_engine/scripts/tools/validate_documentation_governance.py tests/test_validate_documentation_governance.py
- ./.venv/bin/python -m pytest \tests/__init__.py
tests/agent_evals/run_evals.py
tests/artifact_helpers.py
tests/conftest.py
tests/test_ai_client.py
tests/test_apex_infrastructure.py
tests/test_bootstrap_from_matrix.py
tests/test_build_case_input.py
tests/test_build_global_report_payload.py
tests/test_build_tower_annex_template_payload.py
tests/test_client_intelligence.py
tests/test_contract_handover.py
tests/test_document_integrity.py
tests/test_environment.py
tests/test_generate_smoke_data.py
tests/test_global_coherence.py
tests/test_global_maturity_policy.py
tests/test_json_parser.py
tests/test_maturity_band.py
tests/test_maturity_band_characterization.py
tests/test_mcp_server.py
tests/test_payload_validation.py
tests/test_pipeline_env_propagation.py
tests/test_pipeline_runtime.py
tests/test_po_run_wrapper.py
tests/test_product_owner_prompts.py
tests/test_prompt_registry.py
tests/test_remediation_playbooks.py
tests/test_render_commercial_report.py
tests/test_render_global_report.py
tests/test_render_tower_annex.py
tests/test_render_tower_blueprint.py
tests/test_render_web_presentation.py
tests/test_rendering.py
tests/test_run_executive_annex_synthesizer.py
tests/test_run_incremental_quality_gate.py
tests/test_run_incremental_typecheck.py
tests/test_run_intelligence_harvesting.py
tests/test_run_product_owner_orchestrator.py
tests/test_run_scoring.py
tests/test_runtime_paths.py
tests/test_schemas.py
tests/test_secrets_client.py
tests/test_t5_golden.py
tests/test_text_utils.py
tests/test_validate_documentation_governance.py
tests/test_vertex_connection.py -q